### PR TITLE
Set `priorityClassName: system-node-critical` for teleport daemonset

### DIFF
--- a/teleport-daemonset/templates/daemonset.yaml
+++ b/teleport-daemonset/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         effect: "NoSchedule"
     {{- end }}
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: {{ .Chart.Name }}-systemd-installer
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Set `priorityClassName: system-node-critical` for teleport daemonset