### PR TITLE
Remove default value for `service account`

### DIFF
--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -4,7 +4,7 @@ serviceAccount:
   create: false
   annotations:
   labels:
-  name: default
+  name: 
 
 dockercfg:
   enabled: false


### PR DESCRIPTION
## What
* Remove default name for the service account


## Why
* If a name for service account would be empty - chart full name will be used