### PR TITLE
Trust secret name given by tls block

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.1.5
+appVersion: 1.1.6
 
 home: https://github.com/SpotOnInc/helmcharts
 icon: https://github.com/SpotOnInc/helmcharts/spoton-logo.png

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -62,7 +62,6 @@ spec:
 {{- with $ingress.tls }}
   tls:
 {{ toYaml . | indent 4 }}
-      secretName: devops-ghactions-tls
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This was overwriting any secretName that was pulled in via the `ingress.tls` block from the values.

This is fine for a single service in a single namespace, but once you have two ingresses in the same namespace that both want tls certs, it will break because the name will be the same for all of them, overwriting the secret and so the newest ingress always wins.

Current behavior:
```
 ⧉  SpotOn Inc (us-east-1.staging.spoton.sh:spoton-plus)
 √ . [spoton-gbl-identity-admin] / ⨠ helmfile -f /localhost/work/spoton-plus/deploy/helmfile.yaml --namespace=spoton-plus --environment=staging template | grep '\bsecretName:'
Adding repo spoton-helmcharts git+https://github.com/SpotOnInc/helmcharts@monochart
"spoton-helmcharts" has been added to your repositories

Templating release=spoton-plus-dev-00-celery-worker, chart=spoton-helmcharts/spoton-monochart
Templating release=spoton-plus-dev-00-recommendation, chart=spoton-helmcharts/spoton-monochart
      secretName: spoton-plus-recommendation-service-tls
      secretName: devops-ghactions-tls
Templating release=spoton-plus-dev-00, chart=spoton-helmcharts/spoton-monochart
      secretName: spoton-plus-training-tls
      secretName: devops-ghactions-tls
Templating release=spoton-plus-dev-00-celery-beat, chart=spoton-helmcharts/spoton-monochart
Templating release=spoton-plus-dev-00-admin, chart=spoton-helmcharts/spoton-monochart
      secretName: devops-ghactions-tls
      
```

New behavior:

```
 ⧉  SpotOn Inc (us-east-1.staging.spoton.sh:spoton-plus)
 √ . [spoton-gbl-identity-admin] / ⨠ helmfile -f /localhost/work/spoton-plus/deploy/helmfile.yaml --namespace=spoton-plus --environment=staging template | grep '\bsecretName:'
Adding repo spoton-helmcharts git+https://github.com/SpotOnInc/helmcharts@monochart?ref=88f788d2e164453d2fab8f34d6802a24b344b13c
"spoton-helmcharts" has been added to your repositories

Templating release=spoton-plus-dev-00-celery-worker, chart=spoton-helmcharts/spoton-monochart
Templating release=spoton-plus-dev-00-recommendation, chart=spoton-helmcharts/spoton-monochart
      secretName: spoton-plus-recommendation-service-tls
Templating release=spoton-plus-dev-00, chart=spoton-helmcharts/spoton-monochart
      secretName: spoton-plus-training-tls
Templating release=spoton-plus-dev-00-celery-beat, chart=spoton-helmcharts/spoton-monochart
Templating release=spoton-plus-dev-00-admin, chart=spoton-helmcharts/spoton-monochart
```