### PR TITLE
Add simple extracontainers to Pod manifest

### DIFF
--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -174,6 +174,12 @@ spec:
         lifecycle:
 {{ toYaml .Values.deployment.pod.lifecycle | indent 10 }}
         {{- end }}
+
+{{- with .Values.deployment.pod.extracontainers }}
+{{ toYaml . | indent 6 }}
+{{- end }}
+
+
 {{- with .Values.deployment.pod.hostAliases }}
       hostAliases:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
E.g. in https://github.com/SpotOnInc/teamwork-php-api/blob/a56ddf1689bcb26a3baf39dab4c2e259147d39b6/deploy/releases/teamwork-php-api.yaml#L121

add simple Nginx container from https://kubernetes.io/docs/concepts/workloads/pods/#using-pods

```yaml
releases:
  - values:
      - deployment:
          pod:
            extracontainers:
              - name: nginx
                image: nginx:1.14.2
                ports:
                - containerPort: 80
```