### PR TITLE
Allow statefulsets to use extra volumes and volumemounts in the same …

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.8
+version: 1.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -28,7 +28,7 @@ icon: https://github.com/SpotOnInc/helmcharts/spoton-logo.png
 
 
 maintainers:
-- name: Spoton DevOps 
+- name: Spoton DevOps
   email: devops@spoton.com
 
 annotations:

--- a/monochart/templates/statefulset.yaml
+++ b/monochart/templates/statefulset.yaml
@@ -99,6 +99,12 @@ spec:
         - mountPath: {{ .Values.statefulset.persistence.mountPath | quote }}
           name: {{ include "common.fullname" . }}
         {{- end }}
+        {{- if .Values.FirstVolumeMounts }}
+{{ tpl .Values.FirstVolumeMounts . | indent 8 }}
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
+        {{- end }}
         {{- include "monochart.files.volumeMounts" . | nindent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
@@ -121,6 +127,9 @@ spec:
       {{- end }}
 {{- end }}
       volumes:
+        {{- if .Values.VolumeMountsConfig }}
+{{ tpl .Values.VolumeMountsConfig . | indent 8 }}
+        {{- end }}
 {{ include "monochart.files.volumes" . | indent 6 }}
 {{- if .Values.statefulset.persistence.enabled }}
 {{- if not .Values.statefulset.persistence.useVolumeClaimTemplates }}


### PR DESCRIPTION
…way deployment does
The original request was to unfork helm chart used by boomi that uses extra volumes and volumemounts in a statefulset.
Let me know if I should clarify anything or make it better.

Should I bump chart version also? I've seen mixed PR, some did, some didn't.