### PR TITLE
DEV-5162: Monochart - add support for ingressClass

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.2.0
+appVersion: 1.1.7
 
 home: https://github.com/SpotOnInc/helmcharts
 icon: https://github.com/SpotOnInc/helmcharts/spoton-logo.png

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.10
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.1.7
+appVersion: 1.2.0
 
 home: https://github.com/SpotOnInc/helmcharts
 icon: https://github.com/SpotOnInc/helmcharts/spoton-logo.png

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -35,6 +35,9 @@ metadata:
     ingressName: {{ $name }}
   name: {{ include "common.fullname" $root }}-{{ $name }}
 spec:
+{{- if semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version }}
+  ingressClassName: {{ $ingress.className }}
+{{- end }}
   rules:
 {{- range $host, $path := $ingress.hosts }}
     - host: {{ $host | quote }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -452,6 +452,7 @@ persistence:
 # Ingress for load balancer
 ingress:
   default:
+    className: nginx
     enabled: false
 #    port: port-name
 #    labels:


### PR DESCRIPTION
* add support for ingressClass parameter if Kubernetes version >= 1.19
* defaults to ingressClass = "nginx"
* helm template ./monochart produces clean output w/o any errors
