### PR TITLE
DEV-5162: Monochart - add support for ingressClass

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.10
+version: 1.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -35,6 +35,9 @@ metadata:
     ingressName: {{ $name }}
   name: {{ include "common.fullname" $root }}-{{ $name }}
 spec:
+{{- if semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version }}
+  ingressClassName: {{ $ingress.className }}
+{{- end }}
   rules:
 {{- range $host, $path := $ingress.hosts }}
     - host: {{ $host | quote }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -35,7 +35,7 @@ metadata:
     ingressName: {{ $name }}
   name: {{ include "common.fullname" $root }}-{{ $name }}
 spec:
-{{- if semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version }}
+{{- if and ( hasKey $ingress "className" ) ( and  $ingress.className (semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version) ) }}
   ingressClassName: {{ $ingress.className }}
 {{- end }}
   rules:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -451,6 +451,7 @@ persistence:
 
 # Ingress for load balancer
 ingress:
+  className: nginx
   default:
     enabled: false
 #    port: port-name

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -451,9 +451,9 @@ persistence:
 
 # Ingress for load balancer
 ingress:
-  className: nginx
   default:
     enabled: false
+#    className: nginx # <-- set ingressClass for this ingress resource
 #    port: port-name
 #    labels:
 #      dns: "route53"


### PR DESCRIPTION
* Re-introducing the change that adds support for ingressClass
* IngressClass object for ingress-nginx is described here: https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/#i-have-only-one-ingress-controller-in-my-cluster-what-should-i-do
* ingressClassName parameter will be added when 2 conditions are met: Kubernetes version >= 1.19 + `className` added for the ingress resource in values.yaml
* There is no default value for `className` because we use these 3 controllers (ingress classes): nginx, oidc-ingress, alb. 
* These classes are provided in helmfiles configuration as annotations - verified for corp, staging, prod Kops clusters
* This PR shouldn't break anything as the value of `className` is not being added to helmfiles at the moment. To use this property in Kops clusters, we need to create IngressClass resources for nginx, oidc-nginx and alb classes