### PR TITLE
spoton-monochart -- drop old version support

### DIFF
--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -1,29 +1,23 @@
-{{- $root := . -}}
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
-# Check for using "networking.k8s.io/v1" is incorrect - https://github.com/jaegertracing/helm-charts/pull/279
 ---
-{{- if semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
 {{- with $ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if $root.Values.IncludeForecastleEnv.enabled }}
+{{- if .Values.IncludeForecastleEnv.enabled }}
     # Forecastle gives you access to a control panel where you can see your running applications and access them on Kubernetes.
     # https://github.com/stakater/Forecastle
     # Show the app on the forecastle panel
     forecastle.stakater.com/expose: "true"
     # Name of the group to put this app.. Use if you want to show in different group  than the namespace.
-    forecastle.stakater.com/group: {{ $root.Values.IncludeForecastleEnv.group }}
+    forecastle.stakater.com/group: {{ .Values.IncludeForecastleEnv.group }}
     # A comma separated list of name of the forecastle instance. Use when you have multiple forecastle dashboards
-    forecastle.stakater.com/instance: {{ $root.Values.IncludeForecastleEnv.instance }}
+    forecastle.stakater.com/instance: {{ .Values.IncludeForecastleEnv.instance }}
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
@@ -31,11 +25,11 @@ metadata:
 {{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{ include "common.labels.standard" $root | indent 4 }}
+{{ include "common.labels.standard" . | indent 4 }}
     ingressName: {{ $name }}
-  name: {{ include "common.fullname" $root }}-{{ $name }}
+  name: {{ include "common.fullname" . }}-{{ $name }}
 spec:
-{{- if and ( hasKey $ingress "className" ) ( and  $ingress.className (semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version) ) }}
+{{- if and ( hasKey $ingress "className" )}}
   ingressClassName: {{ $ingress.className }}
 {{- end }}
   rules:
@@ -44,7 +38,6 @@ spec:
       http:
         paths:
           - path: {{ $path }}
-{{- if semverCompare ">=1.19" $root.Capabilities.KubeVersion.Version }}
             pathType: Prefix
             backend:
               service:
@@ -55,16 +48,11 @@ spec:
 {{- else }}
                   name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
 {{- end }}
-{{- else }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
-{{- end }}
-
 {{- end -}}
 {{- with $ingress.tls }}
   tls:
 {{ toYaml . | indent 4 }}
 {{- end -}}
 {{- end -}}
+
 {{- end -}}


### PR DESCRIPTION
EKS doesn't properly semVer -- https://github.com/aws/containers-roadmap/issues/1404#issuecomment-1140384090 -- and it doesn't look like that will change soon. This pr removes the semVer logic because we don't run old clusters anyway. 