### PR TITLE
spoton-monochart - restore namespace variable

### DIFF
--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
@@ -9,15 +10,15 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.IncludeForecastleEnv.enabled }}
+{{- if $root.Values.IncludeForecastleEnv.enabled }}
     # Forecastle gives you access to a control panel where you can see your running applications and access them on Kubernetes.
     # https://github.com/stakater/Forecastle
     # Show the app on the forecastle panel
     forecastle.stakater.com/expose: "true"
     # Name of the group to put this app.. Use if you want to show in different group  than the namespace.
-    forecastle.stakater.com/group: {{ .Values.IncludeForecastleEnv.group }}
+    forecastle.stakater.com/group: {{ $root.Values.IncludeForecastleEnv.group }}
     # A comma separated list of name of the forecastle instance. Use when you have multiple forecastle dashboards
-    forecastle.stakater.com/instance: {{ .Values.IncludeForecastleEnv.instance }}
+    forecastle.stakater.com/instance: {{ $root.Values.IncludeForecastleEnv.instance }}
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}


### PR DESCRIPTION
trying to fix
```
  Error: template: spoton-monochart/templates/ingress.yaml:12:14: executing “spoton-monochart/templates/ingress.yaml” at <.Values.IncludeForecastleEnv.enabled>: nil pointer evaluating interface {}.IncludeForecastleEnv
```