### PR TITLE
DEV-5459: spoton-monochart inline env fix

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.12
+version: 1.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/_helpers.tpl
+++ b/monochart/templates/_helpers.tpl
@@ -65,7 +65,6 @@ env:
 https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
 */}}
 {{- with $root.Values.envFromFieldRefFieldPath }}
-env:
 {{- range $name, $value := . }}
   - name: {{ $name }}
     valueFrom:

--- a/monochart/templates/_helpers.tpl
+++ b/monochart/templates/_helpers.tpl
@@ -54,8 +54,8 @@ envFrom:
 {{- end }}
 {{- end -}}
 {{- end }}
-{{- with $root.Values.env }}
 env:
+{{- with $root.Values.env }}
 {{- range $name, $value := . }}
   - name: {{ $name }}
     value: {{ default "" $value | quote }}


### PR DESCRIPTION
## Changes

- In the _helpers.tpl template, move the first `env:` up before the `with`, and remove the second `env`.

## Why

There is much more detail in [the ticket](https://spotonteam.atlassian.net/browse/DEV-5459), but the short answer is that the `env` value was getting clobbered if `envFromFieldRefFieldPath` was set.

## Testing

I tested several scenarios:

One is the fix for the project mentioned in the ticket, to make sure both sets of environment variables were pulled in:

```yaml
    spec:
      containers:
      - env:
        - name: DD_ENV
          value: unlimited
        - name: DD_SERVICE
          value: merchant-dashboard-frontend
        - name: DD_VERSION
          value: 215a7ae
        - name: FLAVOR
          value: unlimited
        - name: GITHUB_TOKEN
          value: XXXXXXXXXXXXXXXXXXXXXXXXXXXX
        - name: IS_EPHEMERAL
          value: "True"
        - name: RELEASE_NAMESPACE
          value: pr-265-merchant-dashboard-frontend
        - name: RELEASE_VERSION
          value: 0.0.0
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.hostIP
```

The next scenario, I removed the `env` section just to be sure the `envFromFieldRefFieldPath` values would get pulled in.

```yaml
    spec:
      containers:
      - env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.hostIP
```

Next, I tested with no environment variables at all, just to ensure that an empty `env:` wouldn't break the job.

```yaml
    spec:
      containers:
(no env was present)
```

Finally, I tested with my test project, monochart-testing, just to ensure regular deployments weren't affected. It has no inline environment variables (it uses a configmap), so of course it was not.
