### PR TITLE
DEV-5535: spoton-monochart: default deployment to false

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.13
+version: 1.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -115,7 +115,7 @@ initcontainers:
   extraInitContainer: {}
 
 deployment:
-  enabled: true
+  enabled: false
   ## Pods replace strategy
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   # strategy: {}


### PR DESCRIPTION
## Changes

- In `moonochart/values.yaml`, default `deployment:` to `false`.

## Why

By defaulting it to `true`, it will be included for every helmfile, unless the file explicitly sets it to `false`.

## Testing

I added testing info to this ticket [comment](https://spotonteam.atlassian.net/browse/DEV-5535?focusedCommentId=762990).