### PR TITLE
DEV-5550 fix monochart for supporting tolerations

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.13
+version: 1.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -96,19 +96,6 @@ spec:
         resources:
 {{ toYaml .Values.initContainer.resources | indent 10 }}
         {{- end }}
-
-        {{- if .Values.nodeSelector }}
-        nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-        {{- end }}
-        {{- if .Values.affinity }}
-        affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-        {{- end }}
-        {{- if .Values.tolerations }}
-        tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-        {{- end }}
       {{- end }}
 
 
@@ -152,20 +139,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
-
-        {{- if .Values.nodeSelector }}
-        nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-        {{- end }}
-        {{- if .Values.affinity }}
-        affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-        {{- end }}
-        {{- if .Values.tolerations }}
-        tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-        {{- end }}
-
 
         {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
Remove wrong fields in monochart. 
This fields don't exist on this level. They exist only in `spec`

```
k explain deployment.spec.template.spec.initContainers

k explain deployment.spec.template.spec.containers
```