### PR TITLE
DEV-5887 DEV-5819 monochart with ALB

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.14
+version: 1.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -22,6 +22,39 @@ metadata:
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
+{{- if $ingress.alb_enabled }}
+    # Expose paths to public access (without ZScaler)
+  {{- range $host, $paths := $ingress.hosts }}
+    {{- range $idx, $path := $paths }}
+    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-{{ $host }}-{{ $idx }}: '{
+      "type":"forward",
+      "forwardConfig":{
+        "targetGroups":[{
+          "serviceName":"{{ $serviceName }}",
+          "servicePort":{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }} {{ $ingress.port }}
+                        {{- else }} {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
+                        {{- end }},
+          "weight":100}
+        ]}
+    }'
+    {{- end }}
+  {{- end }}
+    # Block entire traffic except ZScaler users
+      # ZScaler Private Access IPs:
+      # - 34.238.231.165
+      # - 34.202.59.188
+      # - 34.197.162.237
+    alb.ingress.kubernetes.io/conditions.{{ $serviceName }}: '[{
+      "field":"source-ip",
+      "sourceIpConfig": {
+        "values":[
+          "34.238.231.165/32",
+          "34.202.59.188/32",
+          "34.197.162.237/32"
+        ]
+      }
+    }]'
+{{- end }}
   labels:
 {{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}
@@ -34,21 +67,47 @@ spec:
   ingressClassName: {{ $ingress.className }}
 {{- end }}
   rules:
-{{- range $host, $path := $ingress.hosts }}
+{{- range $host, $paths := $ingress.hosts }}
     - host: {{ $host | quote }}
       http:
         paths:
+          {{- if $ingress.alb_enabled }}
+          # ALB support (EKS)
+          {{- range $idx, $path := $paths }}
           - path: {{ $path }}
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $serviceName }}-{{ $host }}-{{ $idx }}
+                port:
+                  name: use-annotation
+          {{- end }}
+          # Part of annotation rule for block entire traffic except for ZScaler users
+          - path: /
             pathType: Prefix
             backend:
               service:
                 name: {{ $serviceName }}
                 port:
-{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
+                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
                   number: {{ $ingress.port }}
-{{- else }}
+                  {{- else }}
                   name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
-{{- end }}
+                  {{- end }}
+          {{- else }}
+          # A pattern we use with NLB (KOPS mostly)
+          - path: {{ $paths }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
+                  number: {{ $ingress.port }}
+                  {{- else }}
+                  name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
+                  {{- end }}
+          {{- end }}
 {{- end -}}
 {{- with $ingress.tls }}
   tls:

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -32,8 +32,8 @@ metadata:
       "forwardConfig":{
         "targetGroups":[{
           "serviceName":"{{ $serviceName }}",
-          "servicePort":{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }} {{ $ingress.port }}
-                        {{- else }} {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
+          "servicePort":{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }} {{ $ingress.port | quote }}
+                        {{- else }} {{ hasKey $ingress "port" | ternary $ingress.port "default" | quote }} 
                         {{- end }},
           "weight":100}
         ]}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -26,7 +26,8 @@ metadata:
     # Expose paths to public access (without ZScaler)
   {{- range $host, $paths := $ingress.hosts }}
     {{- range $idx, $path := $paths }}
-    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-{{ $host }}-{{ $idx }}: '{
+    # Note the name (actions.<name>) can't be longer than 63 characters
+    alb.ingress.kubernetes.io/actions.{{ $host }}-{{ $idx }}: '{
       "type":"forward",
       "forwardConfig":{
         "targetGroups":[{
@@ -78,7 +79,7 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: {{ $serviceName }}-{{ $host }}-{{ $idx }}
+                name: {{ $host }}-{{ $idx }}
                 port:
                   name: use-annotation
           {{- end }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -86,7 +86,7 @@ spec:
       http:
         paths:
           {{\* 
-            Create public URL paths (endpoints) for Application Load Balancer. The condition will veirfy that the
+            Create public URL paths (endpoints) for Application Load Balancer. The condition will verify that the
             ingress class name is as expected.
           */}}
           {{- if or 

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -24,10 +24,8 @@ metadata:
 {{- end }}
 {{- if $ingress.alb_enabled }}
     # Expose paths to public access (without ZScaler)
-  {{- range $host, $paths := $ingress.hosts }}
-    {{- range $idx, $path := $paths }}
     # Note the name (actions.<name>) can't be longer than 63 characters
-    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-{{ $idx }}: '{
+    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
       "type":"forward",
       "forwardConfig":{
         "targetGroups":[{
@@ -38,8 +36,6 @@ metadata:
           "weight":100}
         ]}
     }'
-    {{- end }}
-  {{- end }}
     # Block entire traffic except ZScaler users
       # ZScaler Private Access IPs:
       # - 34.238.231.165
@@ -74,12 +70,12 @@ spec:
         paths:
           {{- if $ingress.alb_enabled }}
           # ALB support (EKS)
-          {{- range $idx, $path := $paths }}
-          - path: {{ $path }}
+          {{- range $paths }}
+          - path: {{ . }}
             pathType: Exact
             backend:
               service:
-                name: {{ $serviceName }}-{{ $idx }}
+                name: {{ $serviceName }}-public
                 port:
                   name: use-annotation
           {{- end }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
   {{- range $host, $paths := $ingress.hosts }}
     {{- range $idx, $path := $paths }}
     # Note the name (actions.<name>) can't be longer than 63 characters
-    alb.ingress.kubernetes.io/actions.{{ $host }}-{{ $idx }}: '{
+    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-{{ $idx }}: '{
       "type":"forward",
       "forwardConfig":{
         "targetGroups":[{
@@ -79,7 +79,7 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: {{ $host }}-{{ $idx }}
+                name: {{ $serviceName }}-{{ $idx }}
                 port:
                   name: use-annotation
           {{- end }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -22,7 +22,24 @@ metadata:
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
-{{- if $ingress.alb_enabled }}
+  {{- /* 
+  Annotations below are necessary for Application Load Balancer to allow access to only ZScaler users and expose only
+  some of the choosen URL paths (endpoints).
+
+  Skip making them if that's internal ALB. Other way check if ingress class is as expected:
+  
+  if className key is present check if value indicate the ALB usage
+  or 
+  if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
+
+  */}}
+  {{- if and 
+    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
+      or 
+        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+        (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+      )
+  }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters
     alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
@@ -51,7 +68,7 @@ metadata:
         ]
       }
     }]'
-{{- end }}
+  {{- end }}
   labels:
 {{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}
@@ -68,7 +85,14 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          {{- if $ingress.alb_enabled }}
+          {{\* 
+            Create public URL paths (endpoints) for Application Load Balancer. The condition will veirfy that the
+            ingress class name is as expected.
+          */}}
+          {{- if or 
+            (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+            (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+          }}
           # ALB support (EKS)
           {{- range $paths }}
           - path: {{ . }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -453,7 +453,6 @@ persistence:
 ingress:
   default:
     enabled: false
-    alb_enabled: false
 #    className: nginx # <-- set ingressClass for this ingress resource
 #    port: port-name
 #    labels:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -453,6 +453,7 @@ persistence:
 ingress:
   default:
     enabled: false
+    alb_enabled: false
 #    className: nginx # <-- set ingressClass for this ingress resource
 #    port: port-name
 #    labels:


### PR DESCRIPTION
- adding URL path filtering functionality that is available on Application Load Balancer to monochart's ingress
- this will allow us to benefit from ALB listener rules to for example: prevents from unauthorized access

Example helmfile

```yaml
(...)
        ingress:
          default:
             annotations:
               kubernetes.io/ingress.class: alb
             hosts:
               '{{ env "APP_HOST" }}': 
                 - /status
                 - /api/v1/request
```