### PR TITLE
Emergency fix prod deployment issue

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.15
+version: 1.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -44,8 +44,7 @@ spec:
           */}}
           {{- if or 
             (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
-            (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-          }}
+            (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") }}
             {{- if ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal" }}
           # ALB support (EKS)
               {{- range $paths }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -32,12 +32,13 @@ metadata:
   or 
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
-  */}}
+  */ }}
   {{- if and 
       ( or 
         (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-      ) (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") 
+      ) 
+      (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") 
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -33,12 +33,11 @@ metadata:
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
   */}}
-  {{- if and (
-      or 
+  {{- if and 
+      ( or 
         (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-      )
-      (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal")
+      ) (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") 
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -33,8 +33,6 @@ metadata:
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
   */}}
-  {{- if and (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") ( or (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") )
-  }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters
     alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
@@ -63,7 +61,6 @@ metadata:
         ]
       }
     }]'
-  {{- end }}
   labels:
 {{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -34,7 +34,7 @@ metadata:
 
   */}}
   {{- if or 
-        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+        (eq $ingress.className "alb") 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
   }}
     # Expose paths to public access (without ZScaler)

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
-  {{- /* 
+  {{/* 
   Annotations below are necessary for Application Load Balancer to allow access to only ZScaler users and expose only
   some of the choosen URL paths (endpoints).
 
@@ -32,13 +32,13 @@ metadata:
   or 
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
-  */ }}
+  */}}
   {{- if and 
-      ( or 
+    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
+      or 
         (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-      ) 
-      (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") 
+      )
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -33,9 +33,12 @@ metadata:
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
   */}}
-  {{- if or 
-        (eq $ingress.className "alb") 
+  {{- if and 
+    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
+      or 
+        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+      )
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -2,14 +2,27 @@
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
-
-  {{- if and 
-    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
-      or 
-        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
-        (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-      )
-  }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+{{- with $ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if $root.Values.IncludeForecastleEnv.enabled }}
+    # Forecastle gives you access to a control panel where you can see your running applications and access them on Kubernetes.
+    # https://github.com/stakater/Forecastle
+    # Show the app on the forecastle panel
+    forecastle.stakater.com/expose: "true"
+    # Name of the group to put this app.. Use if you want to show in different group  than the namespace.
+    forecastle.stakater.com/group: {{ $root.Values.IncludeForecastleEnv.group }}
+    # A comma separated list of name of the forecastle instance. Use when you have multiple forecastle dashboards
+    forecastle.stakater.com/instance: {{ $root.Values.IncludeForecastleEnv.instance }}
+    # Use a different name, if empty will use the default app name.
+    # forecastle.stakater.com/appName: "emaster-pos-dev-00"
+{{- end }}
+  {{- if eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb" }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters
     alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
@@ -39,6 +52,73 @@
       }
     }]'
   {{- end }}
+  labels:
+{{- with $ingress.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{ include "common.labels.standard" $root | indent 4 }}
+    ingressName: {{ $name }}
+  name: {{ include "common.fullname" $root }}-{{ $name }}
+spec:
+{{- if and ( hasKey $ingress "className" )}}
+  ingressClassName: {{ $ingress.className }}
+{{- end }}
+  rules:
+    {{- range $host, $paths := $ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          {{/* 
+            Create public URL paths (endpoints) for Application Load Balancer. The condition will verify that the
+            ingress class name is as expected.
+          */}}
+          {{- if or 
+            (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+            (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+          }}
+            {{- if ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal" }}
+          # ALB support (EKS)
+              {{- range $paths }}
+          - path: {{ . }}
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $serviceName }}-public
+                port:
+                  name: use-annotation
+              {{- end }}
+          # Part of annotation rule for block entire traffic except for ZScaler users
+            {{- end }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
+                  number: {{ $ingress.port }}
+                  {{- else }}
+                  name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
+                  {{- end }}
+          {{- else }}
+          # A pattern we use with NLB (KOPS mostly)
+          - path: {{ $paths }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
+                  number: {{ $ingress.port }}
+                  {{- else }}
+                  name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
+                  {{- end }}
+          {{- end }}
+    {{- end -}}
+  {{- with $ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+  {{- end -}}
 {{- end -}}
 
 {{- end -}}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -33,12 +33,12 @@ metadata:
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
   */}}
-  {{- if and 
-    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
+  {{- if and (
       or 
         (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
         (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
       )
+      (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal")
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -2,92 +2,43 @@
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-{{- with $ingress.annotations }}
-  annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{- if $root.Values.IncludeForecastleEnv.enabled }}
-    # Forecastle gives you access to a control panel where you can see your running applications and access them on Kubernetes.
-    # https://github.com/stakater/Forecastle
-    # Show the app on the forecastle panel
-    forecastle.stakater.com/expose: "true"
-    # Name of the group to put this app.. Use if you want to show in different group  than the namespace.
-    forecastle.stakater.com/group: {{ $root.Values.IncludeForecastleEnv.group }}
-    # A comma separated list of name of the forecastle instance. Use when you have multiple forecastle dashboards
-    forecastle.stakater.com/instance: {{ $root.Values.IncludeForecastleEnv.instance }}
-    # Use a different name, if empty will use the default app name.
-    # forecastle.stakater.com/appName: "emaster-pos-dev-00"
-{{- end }}
-  labels:
-{{- with $ingress.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{ include "common.labels.standard" $root | indent 4 }}
-    ingressName: {{ $name }}
-  name: {{ include "common.fullname" $root }}-{{ $name }}
-spec:
-{{- if and ( hasKey $ingress "className" )}}
-  ingressClassName: {{ $ingress.className }}
-{{- end }}
-  rules:
-    {{- range $host, $paths := $ingress.hosts }}
-    - host: {{ $host | quote }}
-      http:
-        paths:
-          {{/* 
-            Create public URL paths (endpoints) for Application Load Balancer. The condition will verify that the
-            ingress class name is as expected.
-          */}}
-          {{- if or 
-            (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
-            (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") }}
-            {{- if ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal" }}
-          # ALB support (EKS)
-              {{- range $paths }}
-          - path: {{ . }}
-            pathType: Exact
-            backend:
-              service:
-                name: {{ $serviceName }}-public
-                port:
-                  name: use-annotation
-              {{- end }}
-          # Part of annotation rule for block entire traffic except for ZScaler users
-            {{- end }}
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $serviceName }}
-                port:
-                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
-                  number: {{ $ingress.port }}
-                  {{- else }}
-                  name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
-                  {{- end }}
-          {{- else }}
-          # A pattern we use with NLB (KOPS mostly)
-          - path: {{ $paths }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $serviceName }}
-                port:
-                  {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
-                  number: {{ $ingress.port }}
-                  {{- else }}
-                  name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
-                  {{- end }}
-          {{- end }}
-    {{- end -}}
-  {{- with $ingress.tls }}
-  tls:
-{{ toYaml . | indent 4 }}
-  {{- end -}}
+
+  {{- if and 
+    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
+      or 
+        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+        (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+      )
+  }}
+    # Expose paths to public access (without ZScaler)
+    # Note the name (actions.<name>) can't be longer than 63 characters
+    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
+      "type":"forward",
+      "forwardConfig":{
+        "targetGroups":[{
+          "serviceName":"{{ $serviceName }}",
+          "servicePort":{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }} {{ $ingress.port | quote }}
+                        {{- else }} {{ hasKey $ingress "port" | ternary $ingress.port "default" | quote }} 
+                        {{- end }},
+          "weight":100}
+        ]}
+    }'
+    # Block entire traffic except ZScaler users
+      # ZScaler Private Access IPs:
+      # - 34.238.231.165
+      # - 34.202.59.188
+      # - 34.197.162.237
+    alb.ingress.kubernetes.io/conditions.{{ $serviceName }}: '[{
+      "field":"source-ip",
+      "sourceIpConfig": {
+        "values":[
+          "34.238.231.165/32",
+          "34.202.59.188/32",
+          "34.197.162.237/32"
+        ]
+      }
+    }]'
+  {{- end }}
 {{- end -}}
 
 {{- end -}}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -22,7 +22,21 @@ metadata:
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
-  {{- if eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb" }}
+  {{/* 
+  Annotations below are necessary for Application Load Balancer to allow access to only ZScaler users and expose only
+  some of the choosen URL paths (endpoints).
+
+  Skip making them if that's internal ALB. Other way check if ingress class is as expected:
+  
+  if className key is present check if value indicate the ALB usage
+  or 
+  if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
+
+  */}}
+  {{- if or 
+        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
+        (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
+  }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters
     alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -22,45 +22,6 @@ metadata:
     # Use a different name, if empty will use the default app name.
     # forecastle.stakater.com/appName: "emaster-pos-dev-00"
 {{- end }}
-  {{/* 
-  Annotations below are necessary for Application Load Balancer to allow access to only ZScaler users and expose only
-  some of the choosen URL paths (endpoints).
-
-  Skip making them if that's internal ALB. Other way check if ingress class is as expected:
-  
-  if className key is present check if value indicate the ALB usage
-  or 
-  if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
-
-  */}}
-    # Expose paths to public access (without ZScaler)
-    # Note the name (actions.<name>) can't be longer than 63 characters
-    alb.ingress.kubernetes.io/actions.{{ $serviceName }}-public: '{
-      "type":"forward",
-      "forwardConfig":{
-        "targetGroups":[{
-          "serviceName":"{{ $serviceName }}",
-          "servicePort":{{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }} {{ $ingress.port | quote }}
-                        {{- else }} {{ hasKey $ingress "port" | ternary $ingress.port "default" | quote }} 
-                        {{- end }},
-          "weight":100}
-        ]}
-    }'
-    # Block entire traffic except ZScaler users
-      # ZScaler Private Access IPs:
-      # - 34.238.231.165
-      # - 34.202.59.188
-      # - 34.197.162.237
-    alb.ingress.kubernetes.io/conditions.{{ $serviceName }}: '[{
-      "field":"source-ip",
-      "sourceIpConfig": {
-        "values":[
-          "34.238.231.165/32",
-          "34.202.59.188/32",
-          "34.197.162.237/32"
-        ]
-      }
-    }]'
   labels:
 {{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}
@@ -73,7 +34,7 @@ spec:
   ingressClassName: {{ $ingress.className }}
 {{- end }}
   rules:
-{{- range $host, $paths := $ingress.hosts }}
+    {{- range $host, $paths := $ingress.hosts }}
     - host: {{ $host | quote }}
       http:
         paths:
@@ -123,11 +84,11 @@ spec:
                   name: {{ hasKey $ingress "port" | ternary $ingress.port "default" }}
                   {{- end }}
           {{- end }}
-{{- end -}}
-{{- with $ingress.tls }}
+    {{- end -}}
+  {{- with $ingress.tls }}
   tls:
 {{ toYaml . | indent 4 }}
-{{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- end -}}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -33,12 +33,7 @@ metadata:
   if "kubernetes.io/ingress.class" annotation is present check it's set to use ALB 
 
   */}}
-  {{- if and 
-    (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") (
-      or 
-        (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) 
-        (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") 
-      )
+  {{- if and (ne (index $ingress.annotations "alb.ingress.kubernetes.io/scheme") "internal") ( or (and ( hasKey $ingress "className" ) (eq $ingress.className "alb")) (eq (index $ingress.annotations "kubernetes.io/ingress.class") "alb") )
   }}
     # Expose paths to public access (without ZScaler)
     # Note the name (actions.<name>) can't be longer than 63 characters


### PR DESCRIPTION
- people started reporting issues with deployments
- unfortunately dry-run didn't report any issues
- appeared to be the difference between helmfile version on my machine (0.15x) and on the docker image that's deploying on codefresh (0.13x)
  - I found we're using `prod.spoton.sh` image thats github repository is archived from a long time
  - since the `prod.spoton.sh` dockerfile looks similar to infra I just replaced it in codefresh shared config

To sum up: this PR is not really fixing anything but since I found a cosmetic syntax error I'm fixing it.