### PR TITLE
parallel deployment (kOps default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # helmcharts
 Spoton internal Helm charts repository.
+
+## Notes
+This is the legacy chart repository. It will exist as long as spoton-monochart runs on kOps. All new charts should be hosted at https://github.com/SpotOnInc/helm-repository. 

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.17
+version: 1.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.1.7
+appVersion: 1.1.8
 
 home: https://github.com/SpotOnInc/helmcharts
 icon: https://github.com/SpotOnInc/helmcharts/spoton-logo.png

--- a/monochart/README.md
+++ b/monochart/README.md
@@ -1,12 +1,11 @@
 # Monochart
 
 ## Introduction
-We have to made a fork from https://github.com/cloudposse/charts/tree/master/incubator/monochart, because the CP chart is a bit outdate and don't include all the parameters that we need, like sealedsecrets, initconatiners and networkpolices.
-
+Forked from https://github.com/cloudposse/charts/tree/master/incubator/monochart 
 ## Changes
 
 ### common.labels
-We have changed the common.labes from:
+We have changed the common.labels from:
 
 |before|now|
 |-|-|
@@ -132,46 +131,3 @@ releases:
 ```
 
 These configuration will generate two CMF (ConfigMapsFiles) called **The_Name_of_the_Resource** and **pos-config-template** with the content of the **/path/relative/to/manifest** and **files/pos-config-template.json** respectively.
-
-
-## TODO:
-
-### Helm git plugin
-Helm/helmfile have a plugin that allow use a git repository as a helm chart repository directly.
-This works very easy when you have a public git repository, but in our case, our [helmchart](https://github.com/SpotOnInc/helmcharts/) repository is private and that have generate some problem to access it from CD.
-
-To workaround it, we have followed the idea from @JB to make a clone from the helmchart repository inside of the CD and use this local directory as chart. For example:
-
-```yaml
-# helmfile with public git chart repository.
-repositories:
-  # Spoton helmcharts repository
-  - name: spoton-git
-    url: "git+ssh://git@github.com/
-
-releases:
-  - name: test
-    # the chart this release uses
-    chart: "spoton-git/spoton-monochart
-    version: 1.1.1
-```
-
-the workaround one time that we have the repository cloned
-```yaml
-# helmfile with public git chart repository.
-# repositories:
-#   # Spoton helmcharts repository
-#   - name: spoton-git
-#     url: "git+ssh://git@github.com/
-
-releases:
-  - name: test
-    # the chart this release uses
-    chart: "/codefresh/volume/helmcharts/monochart"
-    version : 1.1.1
-```
-
-This work good for now, **but maybe in the future** we will have performance problem if the repository grow up in size.
-
-### Include DataDog enviroment by default.
-### Include networkpolices on templates.

--- a/monochart/templates/_helpers.tpl
+++ b/monochart/templates/_helpers.tpl
@@ -171,3 +171,33 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+detect if the chart is being deployed to EKS
+*/}}
+{{- define "isEKS" -}}
+{{- if hasKey .Values "nodeSelector" -}}
+  {{- if hasKey .Values.nodeSelector "eks.amazonaws.com/nodegroup" -}}
+    true
+  {{- else }}
+    false
+  {{- end }}
+{{- else }}
+  false
+{{- end }}
+{{- end -}}
+
+{{/*
+filter a key from a dictionary
+*/}}
+{{- define "filterDict" -}}
+  {{- $inDict := index . 0 -}}
+  {{- $target := index . 1 -}}
+  {{- $outDict := dict -}}
+  {{- range $key, $value := $inDict }}
+    {{- if not (strings.Contains $key $target) }}
+      {{- $outDict[$key] = $value }}
+    {{- end }}
+  {{- end }}
+  {{- $outDict }}
+{{- end -}}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -2,6 +2,14 @@
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
+{{/* 
+    parallel deployment to kOps and EKS operate on a basis of 'who owns the external-dns?'
+    in this chart version, kOps is the default platform.
+    EKS deployments are automagically updated to remove the conflicting annotation
+*/}}
+{{- if include "isEKS" . }}
+  {{- $ingress.annotations := include "filterDict" ( list $ingress.annotations "external-dns.alpha.kubernetes.io/target") }}
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
isEKS and filterDict are support functions to make dual deployment sane. 

If monochart is run on an EKS deployment, in this version, the `external-dns` annotations will be automagically stripped to avoid conflicting with the kOps deployment of the same application. 