### PR TITLE
Adding deployment.pod.hostPID value

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.20
+version: 1.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
 
     spec:
       serviceAccountName: {{ template "monochart.serviceAccountName" . }}
+      hostPID: "{{ .Values.deployment.pod.hostPID }}"
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       serviceAccountName: {{ template "monochart.serviceAccountName" . }}
       {{- if .Values.deployment.pod.hostPID }}
-        hostPID: true
+      hostPID: true
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -62,7 +62,9 @@ spec:
 
     spec:
       serviceAccountName: {{ template "monochart.serviceAccountName" . }}
-      hostPID: "{{ .Values.deployment.pod.hostPID }}"
+      {{- if .Values.deployment.pod.hostPID }}
+        hostPID: true
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -143,6 +143,7 @@ deployment:
     # command:
     args: []
     lifecycle: {}
+    hostPID: false
 
 
 FirstVolumeMounts: {}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -143,7 +143,7 @@ deployment:
     # command:
     args: []
     lifecycle: {}
-    hostPID: "false"
+    #hostPID: true
 
 
 FirstVolumeMounts: {}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -143,7 +143,7 @@ deployment:
     # command:
     args: []
     lifecycle: {}
-    #hostPID: true
+    hostPID: false
 
 
 FirstVolumeMounts: {}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -143,7 +143,7 @@ deployment:
     # command:
     args: []
     lifecycle: {}
-    hostPID: false
+    hostPID: "false"
 
 
 FirstVolumeMounts: {}


### PR DESCRIPTION
## Changes

* Adding new value `deployment.pod.hostPID` which defaults to `false`.

## Testing

Setup:

```shell
helm repo add spoton-helmcharts-hostpid git+https://github.com/SpotOnInc/helmcharts@monochart?ref=deployment-hostpid
helm repo update
helm search repo spoton-helmcharts-hostpid
```

I grabbed the values.yaml from a test project like so: `helm get values -n staging monochart-testing`

Then I tested by adding `hostPID` to my values file, and tested without as well:

```shell
helm install test-hostpid spoton-helmcharts-hostpid/spoton-monochart -f monochart-testing.values.yaml --dry-run
```

```shell
⨠ diff output.yaml output2.yaml 
2c2
< LAST DEPLOYED: Wed Oct  4 17:52:52 2023
---
> LAST DEPLOYED: Wed Oct  4 17:50:38 2023
105a106
>       hostPID: true
```

Deployment YAML:

```shell
⨠ cat deployment.yaml | yq .spec.template.spec.hostPID
true
```