### PR TITLE
Allow to alter zscaler IPs list

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.21
+version: 1.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.20
+version: 1.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/README.md
+++ b/monochart/README.md
@@ -309,6 +309,34 @@ Then, we have to update `hosts` section. There are 2 notations supported.
       uses list of `public_paths` to expose a production endpoint to public Internet. It's necessary for customer's
       browser to reach to this endpoint.
 
+#### Use non-default ZScaler proxy IP addresses
+
+By default ZScaler Proxy IP addresses work for most environments. However, if that require customization an example
+below explains how it can be achieved in helmfile.
+
+1. Create `zscalerProxyIPs` variable in your helmfile. 
+
+  ```yaml
+  environments:
+    pci-unlimited:
+      values:
+        - zscalerProxyIPs: 
+          - 54.82.104.143/32
+          - 54.86.79.65/32
+  ```
+
+1. Loop through values of this variable in `ingress` declaration
+
+  ```yaml
+    ingress:
+      default:
+        enabled: true
+        zscalerProxyIPs: 
+        {{ range .Values.zscalerProxyIPs }}
+          - {{ . }}
+        {{ end }}
+  ```
+
 ## TODO
 
 ### Helm git plugin

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -48,7 +48,7 @@ metadata:
       "field":"source-ip",
       "sourceIpConfig": {
         "values":[
-          {{ $ingress.zscalerProxyIPs | default "34.238.231.165/32, 34.202.59.188/32, 34.197.162.237/32" }}
+          {{ $ingress.zscalerProxyIPs | default ( printf "\"%s\", \"%s\", \"%s\"" "34.238.231.165/32" "34.202.59.188/32" "34.197.162.237/32" ) }}
         ]
       }
     }]'

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -43,12 +43,16 @@ metadata:
         ]}
     }'
     # Block entire traffic except ZScaler users
-      # ZScaler Private Access IPs as below
     alb.ingress.kubernetes.io/conditions.{{ $serviceName }}: '[{
       "field":"source-ip",
       "sourceIpConfig": {
         "values":[
-          {{ $ingress.zscalerProxyIPs | default ( printf "\"%s\", \"%s\", \"%s\"" "34.238.231.165/32" "34.202.59.188/32" "34.197.162.237/32" ) }}
+          {{- /* get first element of ZScaler proxy IP list. It doesn't require a comma */ -}}
+          {{- first $ingress.zscalerProxyIPs | quote -}}
+          {{- /* get other elements. They will require comma before the value */ -}}
+          {{- range ( rest $ingress.zscalerProxyIPs ) -}}
+            , {{- . | quote -}}
+          {{- end -}}
         ]
       }
     }]'

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -48,9 +48,7 @@ metadata:
       "field":"source-ip",
       "sourceIpConfig": {
         "values":[
-          "34.238.231.165/32",
-          "34.202.59.188/32",
-          "34.197.162.237/32"
+          {{ $ingress.zscalerProxyIPs | default "34.238.231.165/32","34.202.59.188/32","34.197.162.237/32" }}
         ]
       }
     }]'

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -48,7 +48,7 @@ metadata:
       "field":"source-ip",
       "sourceIpConfig": {
         "values":[
-          {{ $ingress.zscalerProxyIPs | default '"34.238.231.165/32","34.202.59.188/32","34.197.162.237/32"' }}
+          {{ $ingress.zscalerProxyIPs | default "34.238.231.165/32, 34.202.59.188/32, 34.197.162.237/32" }}
         ]
       }
     }]'

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -48,7 +48,7 @@ metadata:
       "field":"source-ip",
       "sourceIpConfig": {
         "values":[
-          {{ $ingress.zscalerProxyIPs | default "34.238.231.165/32","34.202.59.188/32","34.197.162.237/32" }}
+          {{ $ingress.zscalerProxyIPs | default '"34.238.231.165/32","34.202.59.188/32","34.197.162.237/32"' }}
         ]
       }
     }]'

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -454,6 +454,10 @@ persistence:
 ingress:
   default:
     enabled: false
+    zscalerProxyIPs: 
+      - "34.238.231.165/32" 
+      - "34.202.59.188/32" 
+      - "34.197.162.237/32"
 #    className: nginx # <-- set ingressClass for this ingress resource
 #    port: port-name
 #    labels:


### PR DESCRIPTION
- default ZScaler Proxy IPs works well in most AWS VPCs but not everywhere
- we have to have a way to override them