### PR TITLE
keycloak-gatekeeper: ingress template and doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Spoton internal Helm charts repository.
 For instruction how to use check the README in catalogs for individual charts.
 
 ## Notes
-This is the legacy chart repository. It will exist as long as spoton-monochart runs on kOps. All new charts should be hosted at https://github.com/SpotOnInc/helm-repository. 
+This is the legacy chart repository. It will exist as long as spoton-monochart runs on kOps.

--- a/keycloak-gatekeeper/Chart.yaml
+++ b/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak-gatekeeper
-version: 4.1.0
+version: 4.0.1
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:

--- a/keycloak-gatekeeper/Chart.yaml
+++ b/keycloak-gatekeeper/Chart.yaml
@@ -12,8 +12,8 @@ keywords:
   - keycloak
   - proxy
 maintainers:
-  - name: gabibbo97
-    email: gabibbo97@gmail.com
+  - name: Spoton DevOps
+    email: devops@spoton.com
 icon: https://raw.githubusercontent.com/keycloak/keycloak-misc/master/logo/keycloak_logo_600px.svg
 appVersion: "10.0.0"
 deprecated: true

--- a/keycloak-gatekeeper/Chart.yaml
+++ b/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak-gatekeeper
-version: 4.0.0
+version: 4.1.0
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:

--- a/keycloak-gatekeeper/README.md
+++ b/keycloak-gatekeeper/README.md
@@ -2,23 +2,11 @@
 
 [Keycloak gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) is an authentication proxy service which at the risk of stating the obvious integrates with the Keycloak authentication service.
 
-## COPIED NOTICE
+## NOTICE
 
 This chart was copied from: https://github.com/gabibbo97/charts/tree/master/charts/keycloak-gatekeeper
 
 Keycloak Gatekeeper (renamed in `Louketo Proxy`) has been [deprecated by their authors](https://www.keycloak.org/2020/08/sunsetting-louketo-project.adoc)
-
-## TL;DR
-
-```bash
-helm install gabibbo97/keycloak-gatekeeper \
-    --set discoveryURL=https://keycloak.example.com/auth/realms/myrealm \
-    --set upstreamURL=http://my-svc.my-namespace.svc.cluster.local:8088 \
-    --set ClientID=myOIDCClientID \
-    --set ClientSecret=deadbeef-b000-1337-abcd-aaabacadaeaf \
-    --set ingress.enabled=true \
-    --set ingress.hosts[0]=my-svc-auth.example.com
-```
 
 ## Upgrade notes
 

--- a/keycloak-gatekeeper/templates/ingress.yaml
+++ b/keycloak-gatekeeper/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "keycloak-gatekeeper.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") (not (.Capabilities.APIVersions.Has "extensions/v1beta1/Ingress")) }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,7 +28,9 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Changes

* Updated ingress template to be compatible with Kubernetes 1.22.
* Updated README files, maintainers.
* Also removed the note about `helm-repository` from the main README since we've decided not to use that.
* Version bumped to `4.0.1`.

## Reference

* https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122