### PR TITLE
DEV-6071: add spoton-monochart field terminationGracePeriodSeconds

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.22
+version: 1.1.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
       {{- if .Values.deployment.pod.hostPID }}
       hostPID: true
       {{- end }}
+      terminationGracePeriodSeconds: {{.Values.deployment.pod.terminationGracePeriodSeconds }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -144,6 +144,7 @@ deployment:
     args: []
     lifecycle: {}
     hostPID: false
+    terminationGracePeriodSeconds: 30
 
 
 FirstVolumeMounts: {}


### PR DESCRIPTION
## Changes

* Add new field `terminationGracePeriodSeconds` to deployment/pod and default it to 30 (seconds).

## Testing

Setting up the helm chart:

```shell
❯ helm repo add spoton-new-field "git+https://github.com/SpotOnInc/helmcharts@monochart?ref=DEV-6071-monochart-terminationGracePeriodSeconds"
❯ helm repo update
❯ helm search repo spoton-new-field
```

Dry run testing:

```shell
❯ helm install test-new-field spoton-new-field/spoton-monochart -f monochart-testing.values.field-not-set.yaml --dry-run >field_not_set.manifests.yaml
❯ helm install test-new-field spoton-new-field/spoton-monochart -f monochart-testing.values.field-set.yaml --dry-run >field_set.manifests.yaml

❯ diff field_not_set.manifests.yaml field_set.manifests.yaml                                                                                  
2c2
< LAST DEPLOYED: Tue Oct 17 16:51:37 2023
---
> LAST DEPLOYED: Tue Oct 17 16:52:13 2023
107c107
<       terminationGracePeriodSeconds: 30
---
>       terminationGracePeriodSeconds: 90
```

Install test:

```shell
❯ helm install monochart-testing spoton-new-field/spoton-monochart -f monochart-testing.values.field-not-set.yaml
❯ kubectl get deploy monochart-testing -o yaml | yq .spec.template.spec.terminationGracePeriodSeconds
30
```