### PR TITLE
feature(spoton-monochart): sidecars for monochart - the savant version

### DIFF
--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -180,3 +180,6 @@ spec:
       {{- end }}
       {{- include "monochart.files.volumes" . | nindent 6 }}
 {{- end -}}
+      {{- if .Values.sideCars }}
+{{ tpl .Values.sideCars . | indent 6 }}
+      {{- end }}


### PR DESCRIPTION
Allows you to add sidecar containers to a monochart deployment.

Add a new key under release.values:
```yaml
releases:
  values:
    sideCars:
      - name: {{ .sideCar.Name }}
        image: etc:etc
```

It's the savant version because you have to get everything right. Monochart does no checking and will blow up hard if you're wrong. 


First solution for https://spotonteam.atlassian.net/browse/DEV-6250