### PR TITLE
DEV-6279: spoton-monochart cronjob API v1

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{- range $name, $cron := .Values.cronjob -}}
 {{- if $cron.enabled }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}


### PR DESCRIPTION
## What
* For the cronjob template, use the `batch/v1` API instead of `batch/v1beta1`.

## Why
* The `batch/v1beta1` API is no longer available in Kubernetes 1.25. The `batch/v1` API has been available since 1.21, so it is safe for all of our clusters.
* Ticket: https://spotonteam.atlassian.net/browse/DEV-6279
