### PR TITLE
chore:  add infrastructure annotation to catalog-info files

### DIFF
--- a/.spoton/catalog-info.yaml
+++ b/.spoton/catalog-info.yaml
@@ -3,24 +3,24 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: helmcharts
-  description: | 
+  description: |
     Helm chart repository for Spoton projects. A home of Monochart that we're using to deploy every Spoton project.
-  
+
   annotations:
     github.com/project-slug: spotoninc/helmcharts
-  
+
     backstage.io/techdocs-ref: dir:..
-  
+
+    spoton.com/domain: domain:default/infrastructure
   tags:
     - go-template # language
     - helmfile # framework
   links:
-    
-    - title: "Slack (#devops)"
+    - title: Slack (#devops)
       type: contact
       url: https://spoton.slack.com/archives/CFBPX8NMQ
       icon: chat
-      
+
 spec:
   type: library
   owner: group:default/ops


### PR DESCRIPTION
## Description
now that we have a place to add domain labels to our catalog-info files, we should add the infrastructure label to all of our catalog-info files. This will help us to better understand the scope of our infrastructure and how it is being used.
