### PR TITLE
chore: add kubernetes horizontal pod autoscaling object

### DIFF
--- a/monochart/README_HPA.md
+++ b/monochart/README_HPA.md
@@ -14,7 +14,7 @@ This document walks you through an example of enabling HorizontalPodAutoscaler t
 |Key|Value|
 |-|-|
 |hpa.enabled|false|
-|hpa.autoscaling.minReplicas|1|
+|hpa.autoscaling.minReplicas|3|
 |hpa.autoscaling.maxReplicas|10|
 |hpa.autoscaling.targetCPUUtilizationPercentage|90|
 |hpa.autoscaling.targetMemoryUtilizationPercentage|90|

--- a/monochart/README_HPA.md
+++ b/monochart/README_HPA.md
@@ -1,0 +1,23 @@
+# Horizontal Pod Autoscaler (HPA)
+
+## Introduction
+A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resource (such as a Deployment or StatefulSet), with the aim of automatically scaling the workload to match demand.
+
+Horizontal scaling means that the response to increased load is to deploy more Pods. This is different from vertical scaling, which for Kubernetes would mean assigning more resources (for example: memory or CPU) to the Pods that are already running for the workload.
+
+If the load decreases, and the number of Pods is above the configured minimum, the HorizontalPodAutoscaler instructs the workload resource (the Deployment, StatefulSet, or other similar resource) to scale back down.
+
+This document walks you through an example of enabling HorizontalPodAutoscaler to automatically manage scale for an example web app. This example workload is Apache httpd running some PHP code
+
+## Default Values
+
+|Key|Value|
+|-|-|
+|hpa.enabled|false|
+|hpa.autoscaling.minReplicas|1|
+|hpa.autoscaling.maxReplicas|10|
+|hpa.autoscaling.targetCPUUtilizationPercentage|90|
+|hpa.autoscaling.targetMemoryUtilizationPercentage|90|
+
+## Links
+Kubernetes [HPA site](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/)

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -26,7 +26,11 @@ metadata:
     spoton.NetPolicy: disabled
     {{- end }}
 spec:
+{{- if .Values.hpa.enabled }}
+  {{- /*replicas: 0*/ -}}
+  {{- else }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.name" . }}

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,5 +1,6 @@
 {{- $root := . -}}
-{{- if .Values.hpa.enabled }}
+{{- if .Values.hpa -}}
+{{- if .Values.hpa.enabled -}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -19,23 +20,25 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "common.fullname" .  }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.hpa.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.hpa.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
-  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- if .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        averageUtilization: {{ .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}
+{{- end }}
+

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- if .Values.hpa -}}
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -24,7 +24,7 @@ spec:
   metrics:
   {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
-   resource:
+    resource:
       name: cpu
       target:
         type: Utilization

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,0 +1,41 @@
+{{- $root := . -}}
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "common.fullname" .  }}
+{{- with .Values.deployment.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{- include "common.labels.standard" . | nindent 4 }}
+{{- with .Values.deployment.labels }}
+{{ toYaml .| indent 4 }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.fullname" .  }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+   resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -715,9 +715,9 @@ networkPolicy:
 
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 hpa:
-  enabled: true
-  autoscaling:
-    minReplicas: 1
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 90
-    targetMemoryUtilizationPercentage: 90
+  enabled: false
+#   autoscaling:
+#     minReplicas: 1
+#     maxReplicas: 10
+#     targetCPUUtilizationPercentage: 90
+#     targetMemoryUtilizationPercentage: 90

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -716,8 +716,8 @@ networkPolicy:
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 hpa:
   enabled: false
-#   autoscaling:
-#     minReplicas: 3
-#     maxReplicas: 10
-#     targetCPUUtilizationPercentage: 90
-#     targetMemoryUtilizationPercentage: 90
+  autoscaling:
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -712,11 +712,12 @@ networkPolicy:
   #         protocol: TCP
 
 
+
+# https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 hpa:
   enabled: true
-
-autoscaling:
-  minReplicas: 1
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 90
-  targetMemoryUtilizationPercentage: 90
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 90
+    targetMemoryUtilizationPercentage: 90

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -712,3 +712,11 @@ networkPolicy:
   #         protocol: TCP
 
 
+hpa:
+  enabled: true
+
+autoscaling:
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 90
+  targetMemoryUtilizationPercentage: 90

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -717,7 +717,7 @@ networkPolicy:
 hpa:
   enabled: false
 #   autoscaling:
-#     minReplicas: 1
+#     minReplicas: 3
 #     maxReplicas: 10
 #     targetCPUUtilizationPercentage: 90
 #     targetMemoryUtilizationPercentage: 90


### PR DESCRIPTION
What:
* Add Horizontal Pod Autoscaler(HPA) to monochart

Why:
* Kubernetes deployment scale up/down.
* Manage cost more efficiently in an automated way.

```
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /localhost/repos/helmcharts/monochart

---
# Source: spoton-monochart/templates/hpa.yaml

apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  namespace: default
  name: release-name-spoton-monochart
  labels:
    app.kubernetes.io/name: spoton-monochart
    helm.sh/chart: spoton-monochart-1.1.28
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: release-name-spoton-monochart
  minReplicas: 1
  maxReplicas: 10
  metrics:
  - type: Resource
   resource:
      name: cpu
      target:
        type: Utilization
        averageUtilization: 90
  - type: Resource
    resource:
      name: memory
      target:
        type: Utilization
        averageUtilization: 90