### PR TITLE
fix: put proper value in app.kubernetes.io/name label

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.28
+version: 1.1.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.29
+version: 1.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/_common_metadata_labels.tpl
+++ b/monochart/templates/_common_metadata_labels.tpl
@@ -38,7 +38,7 @@ Example output:
 Kubernetes standard labels
 */}}
 {{- define "common.labels.standard" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "common.fullname" . }}
 helm.sh/chart: {{ include "common.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -51,6 +51,6 @@ Labels to use in:
   statefulset.spec.volumeClaimTemplates.labels
 */}}
 {{- define "common.labels.short" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "common.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/monochart/templates/_common_metadata_labels.tpl
+++ b/monochart/templates/_common_metadata_labels.tpl
@@ -38,7 +38,7 @@ Example output:
 Kubernetes standard labels
 */}}
 {{- define "common.labels.standard" -}}
-app.kubernetes.io/name: {{ include "common.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 helm.sh/chart: {{ include "common.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/monochart/templates/_common_metadata_labels.tpl
+++ b/monochart/templates/_common_metadata_labels.tpl
@@ -51,6 +51,6 @@ Labels to use in:
   statefulset.spec.volumeClaimTemplates.labels
 */}}
 {{- define "common.labels.short" -}}
-app.kubernetes.io/name: {{ include "common.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -29,8 +29,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "common.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "common.labels.short" . | nindent 6 }}
 {{- with .Values.deployment.strategy }}
   strategy:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
example of a state right now:

```yaml
  labels:
    app.kubernetes.io/instance: payments-ledger-service-journal-consumer
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: spoton-monochart
    helm.sh/chart: spoton-monochart-1.1.28
    spoton.NetPolicy: enabled
    spoton.NetPolicy.DenyALL: enabled
    tags.spoton.com/team: payments
```


what's in the `app.kubernetes.io/instance` should actually be in `app.kubernetes.io/name` - this is a part of commonly used labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

Grafana Alloy consumes this standard set of labels and expects an actual name under the `app.kubernetes.io/name` label.