### PR TITLE
Fixes for label update utils

### DIFF
--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -21,6 +21,7 @@ check_release_is_monochart() {
   chart=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
   if [[ "$chart" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
+    export NEEDS_UPDATING=false
     exit 0
   fi
 }

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -19,6 +19,24 @@ message() {
   echo
 }
 
+check_release_is_monochart() {
+  chart=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
+  if [[ "$chart" != spoton-monochart* ]]; then
+    message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
+    exit 0
+  fi
+}
+
+get_deployment() {
+  helm_values=$(helm get values -n "$RELEASE_NAMESPACE" "$RELEASE_NAME")
+  DEPLOYMENT=$(yq eval .fullnameOverride <<< "$helm_values")
+
+  if [[ "$DEPLOYMENT" == "null" ]]; then
+    message "⚠️  Could not determine deployment name. Exiting."
+    exit 1
+  fi
+}
+
 RELEASE_NAME=$1
 RELEASE_NAMESPACE=$2
 
@@ -30,13 +48,9 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
   exit 1
 fi
 
-helm_values=$(helm get values -n "$RELEASE_NAMESPACE" "$RELEASE_NAME")
-DEPLOYMENT=$(yq eval .fullnameOverride <<< "$helm_values")
+check_release_is_monochart
+get_deployment
 SERVICE="$DEPLOYMENT"
-if [[ "$DEPLOYMENT" == "null" ]]; then
-  message "⚠️  Could not determine deployment name. Exiting."
-  exit 1
-fi
 
 echo "👷 Confirming that deployment ${DEPLOYMENT} exists before continuing..."
 check_deployment=$(kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT" -o yaml 2>&1)


### PR DESCRIPTION
## What
- Add a check to make sure it's spoton-monochart. If not, it skips it and exits with a `0` exit code so the workflow can continue.
- I also moved the code that gets the deployment name into a function with the idea of adding more in there, but I haven't done anything else with it yet.

## Why
- We shouldn't be processing anything except spoton-monochart releases.

## Testing

### Chart which should be updated

```
 ❯ ./check-if-already-updated.bash monochart-testing dale-testing
***********************************
RELEASE_NAMESPACE: dale-testing
RELEASE_NAME: monochart-testing
DEPLOYMENT: monochart-testing
***********************************
Needs updating.

👷 Confirming that deployment monochart-testing exists before continuing...
***********************************
RELEASE_NAMESPACE: dale-testing
RELEASE_NAME: monochart-testing
DEPLOYMENT: monochart-testing
SERVICE: monochart-testing
TEMP_DEPLOYMENT: monochart-testing-temp
***********************************

⚠️  This was a dry run. No changes were made.
```

### Chart which should not be updated

```
 ❯ ./check-if-already-updated.bash rpos-nats-private restaurant-pos-be-pr-5476

ℹ️  rpos-nats-private is not spoton-monochart. Skipping.

 ❯ ./spoton-monochart-labels-updater.bash rpos-nats-private restaurant-pos-be-pr-5476

ℹ️  rpos-nats-private is not spoton-monochart. Skipping.
```