### PR TITLE
Trying to catch helm release not found errors

### DIFF
--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -19,7 +19,7 @@ message() {
 
 check_release_is_monochart() {
   helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo "$helm_status"
-  if [[ -n "$helm_status" ]] ; then
+  if [[ -n "$helm_status" ]]; then
     message "⚠️  Could not get status for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}. Skipping."
     export NEEDS_UPDATING=false
     exit 0

--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -18,7 +18,7 @@ message() {
 }
 
 check_release_is_monochart() {
-  helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo $helm_status
+  helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo "$helm_status"
   if [[ -n "$helm_status" ]] ; then
     message "⚠️  Could not get status for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}. Skipping."
     export NEEDS_UPDATING=false

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -20,7 +20,13 @@ message() {
 }
 
 check_release_is_monochart() {
-  chart=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
+  helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo $helm_status
+  if [[ -n "$helm_status" ]] ; then
+    message "⚠️  Could not get status for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}. Skipping."
+    exit 0
+  fi
+  helm_history=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml)
+  chart=$(yq eval '.[-1].chart' <<< "$helm_history")
   if [[ "$chart" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
     exit 0
@@ -47,9 +53,6 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
   message '    - RELEASE_NAMESPACE - e.g. staging'
   exit 1
 fi
-
-echo "Skipping."
-exit 0
 
 check_release_is_monochart
 get_deployment

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -21,7 +21,7 @@ message() {
 
 check_release_is_monochart() {
   helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo "$helm_status"
-  if [[ -n "$helm_status" ]] ; then
+  if [[ -n "$helm_status" ]]; then
     message "⚠️  Could not get status for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}. Skipping."
     exit 0
   fi

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -20,7 +20,7 @@ message() {
 }
 
 check_release_is_monochart() {
-  helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo $helm_status
+  helm_status=$(helm status -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml 2>&1 > /dev/null) || echo "$helm_status"
   if [[ -n "$helm_status" ]] ; then
     message "⚠️  Could not get status for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}. Skipping."
     exit 0


### PR DESCRIPTION
## What
* Add an extra check to see if helm will fail trying to query a release
* It exits with a `0` so there's not a failure
* This also removes the "Skipping"; optional, we can leave that in if desired

## Why
* We had a project failing with "release not found" errors running `helm history`. The idea here is to catch a helm failure and then just skip.
* I don't think this should be permanent, just seeing if we can identify what the problems are without impacting deployments.

## Testing

Test with an existing release.
```
❯ ./check-if-already-updated.bash restaurant-etl-dim-tax-staging restaurant-etl
***********************************
RELEASE_NAMESPACE: restaurant-etl
RELEASE_NAME: restaurant-etl-dim-tax-staging
DEPLOYMENT: restaurant-etl-dim-tax
***********************************
Needs updating.

❯ ./spoton-monochart-labels-updater.bash restaurant-etl-dim-tax-staging restaurant-etl
👷 Confirming that deployment restaurant-etl-dim-tax exists before continuing...
***********************************
RELEASE_NAMESPACE: restaurant-etl
RELEASE_NAME: restaurant-etl-dim-tax-staging
DEPLOYMENT: restaurant-etl-dim-tax
SERVICE: restaurant-etl-dim-tax
TEMP_DEPLOYMENT: restaurant-etl-dim-tax-temp
***********************************

⚠️  This was a dry run. No changes were made.
```

Test with a pretend release.
```
❯ ./check-if-already-updated.bash restaurant-etl-dim-tax-staging-foooo restaurant-etl
Error: release: not found

⚠️  Could not get status for restaurant-etl-dim-tax-staging-foooo in namespace restaurant-etl. Skipping.

❯ ./spoton-monochart-labels-updater.bash restaurant-etl-dim-tax-staging-foooo restaurant-etl
Error: release: not found

⚠️  Could not get status for restaurant-etl-dim-tax-staging-foooo in namespace restaurant-etl. Skipping.
```