### PR TITLE
Fixes for utils scripts

### DIFF
--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -22,7 +22,6 @@ check_release_is_monochart() {
   if [[ "$chart_and_version" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
     export NEEDS_UPDATING=false
-    return
   fi
 }
 
@@ -48,6 +47,9 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
 fi
 
 check_release_is_monochart
+if [[ "$NEEDS_UPDATING" == "false" ]] ; then
+  return
+fi
 get_deployment
 
 echo "***********************************"

--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -47,7 +47,7 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
 fi
 
 check_release_is_monochart
-if [[ "$NEEDS_UPDATING" == "false" ]] ; then
+if [[ "$NEEDS_UPDATING" == "false" ]]; then
   return
 fi
 get_deployment

--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -46,34 +46,34 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
   exit 1
 fi
 
+NEEDS_UPDATING=''
 check_release_is_monochart
-if [[ "$NEEDS_UPDATING" == "false" ]]; then
-  return
-fi
-get_deployment
+if [[ "$NEEDS_UPDATING" != "false" ]]; then
+  get_deployment
 
-echo "***********************************"
-echo "RELEASE_NAMESPACE: ${RELEASE_NAMESPACE}"
-echo "RELEASE_NAME: ${RELEASE_NAME}"
-echo "DEPLOYMENT: ${DEPLOYMENT}"
-echo "***********************************"
+  echo "***********************************"
+  echo "RELEASE_NAMESPACE: ${RELEASE_NAMESPACE}"
+  echo "RELEASE_NAME: ${RELEASE_NAME}"
+  echo "DEPLOYMENT: ${DEPLOYMENT}"
+  echo "***********************************"
 
-deployment_yaml=$(kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT" -o yaml 2>&1)
-if [[ "$?" == 1 ]]; then
-  if [[ "$deployment_yaml" =~ "not found" ]]; then
-    echo "⚠️  The deployment ${DEPLOYMENT} does not exist."
-    exit 1
-  else
-    echo "❗ There was an error checking the deployment: $deployment_yaml"
-    exit 1
+  deployment_yaml=$(kubectl get deployment -n "$RELEASE_NAMESPACE" "$DEPLOYMENT" -o yaml 2>&1)
+  if [[ "$?" == 1 ]]; then
+    if [[ "$deployment_yaml" =~ "not found" ]]; then
+      echo "⚠️  The deployment ${DEPLOYMENT} does not exist."
+      exit 1
+    else
+      echo "❗ There was an error checking the deployment: $deployment_yaml"
+      exit 1
+    fi
   fi
-fi
 
-label_app_name=$(yq eval .spec.template.metadata.labels.\"app.kubernetes.io/name\" <<< "$deployment_yaml")
-if [[ "$label_app_name" == "$DEPLOYMENT" ]]; then
-  echo "Already updated."
-  export NEEDS_UPDATING=false
-else
-  echo "Needs updating."
-  export NEEDS_UPDATING=true
+  label_app_name=$(yq eval .spec.template.metadata.labels.\"app.kubernetes.io/name\" <<< "$deployment_yaml")
+  if [[ "$label_app_name" == "$DEPLOYMENT" ]]; then
+    echo "Already updated."
+    export NEEDS_UPDATING=false
+  else
+    echo "Needs updating."
+    export NEEDS_UPDATING=true
+  fi
 fi

--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -22,7 +22,7 @@ check_release_is_monochart() {
   if [[ "$chart" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
     export NEEDS_UPDATING=false
-    exit 0
+    return
   fi
 }
 

--- a/monochart/util/labels-update/check-if-already-updated.bash
+++ b/monochart/util/labels-update/check-if-already-updated.bash
@@ -18,8 +18,8 @@ message() {
 }
 
 check_release_is_monochart() {
-  chart=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
-  if [[ "$chart" != spoton-monochart* ]]; then
+  chart_and_version=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
+  if [[ "$chart_and_version" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
     export NEEDS_UPDATING=false
     return

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -37,8 +37,11 @@ get_deployment() {
   fi
 }
 
+echo "In spoton-monochart-labels-updater.bash"
 RELEASE_NAME=$1
 RELEASE_NAMESPACE=$2
+echo "RELEASE_NAME is ${RELEASE_NAME}"
+echo "RELEASE_NAMESPACE is ${RELEASE_NAMESPACE}"
 
 # Check if the required arguments are present
 if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -48,9 +48,6 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then
   exit 1
 fi
 
-echo "Skipping."
-exit 0
-
 check_release_is_monochart
 get_deployment
 SERVICE="$DEPLOYMENT"

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -37,11 +37,8 @@ get_deployment() {
   fi
 }
 
-echo "In spoton-monochart-labels-updater.bash"
 RELEASE_NAME=$1
 RELEASE_NAMESPACE=$2
-echo "RELEASE_NAME is ${RELEASE_NAME}"
-echo "RELEASE_NAMESPACE is ${RELEASE_NAMESPACE}"
 
 # Check if the required arguments are present
 if [[ -z "$RELEASE_NAME" ]] || [[ -z "$RELEASE_NAMESPACE" ]]; then

--- a/monochart/util/labels-update/spoton-monochart-labels-updater.bash
+++ b/monochart/util/labels-update/spoton-monochart-labels-updater.bash
@@ -20,8 +20,8 @@ message() {
 }
 
 check_release_is_monochart() {
-  chart=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
-  if [[ "$chart" != spoton-monochart* ]]; then
+  chart_and_version=$(helm history -n "$RELEASE_NAMESPACE" "$RELEASE_NAME" -o yaml | yq '.[-1].chart')
+  if [[ "$chart_and_version" != spoton-monochart* ]]; then
     message "ℹ️  ${RELEASE_NAME} is not spoton-monochart. Skipping."
     exit 0
   fi


### PR DESCRIPTION
## What

- Changed the `exit 0` in the check script to `return` to avoid causing the shell of the deployment step to exit.
- Don't use `$chart` for a variable name. The script is being sourced by the pipeline, and that was overriding the value of `$chart` in the pipeline.