### PR TITLE
feat: common labels for domain/subdomain

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.29
+version: 1.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/_common_metadata_labels.tpl
+++ b/monochart/templates/_common_metadata_labels.tpl
@@ -42,6 +42,8 @@ app.kubernetes.io/name: {{ include "common.name" . }}
 helm.sh/chart: {{ include "common.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+spoton.com/domain: {{ .Values.domainName | default "undefined" }}
+spoton.com/subdomain: {{ .Values.subdomainName | default "undefined" }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### What
`spoton.com/domain` and `spoton.com/subdomain` labels are added to common labels to tag all kubernetes resources, in case of getting null, the values is set to `undefined`
### Why
[Ticket](https://spotonteam.atlassian.net/browse/DEV-8041)