### PR TITLE
feat: make NetworkPolicies render correctly, add AllowO11y parameter,…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IntelliJ IDEA files
+.idea

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.29
+version: 1.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- with .Values.deployment.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}
-    # https://github.com/vhs-spoton/personal-doc/blob/main/networkpolices.md
+    # https://docs.corp.spoton.sh/operations/kubernetes/network-policies/
     {{- if .Values.networkPolicy.enabled }}
     spoton.NetPolicy: enabled
         {{- if .Values.networkPolicy.DenyALL.enabled }}

--- a/monochart/templates/networkpolicy.yaml
+++ b/monochart/templates/networkpolicy.yaml
@@ -20,8 +20,8 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Ingress
-  - Egress
+    - Ingress
+    - Egress
 
 {{/* Allow DNS traffic by default. */}}
 ---
@@ -41,14 +41,14 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  - to:
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
+    - to:
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
 
 {{/* Allow TCP/443 traffic by default. */}}
 ---
@@ -68,12 +68,12 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  - to:
-    ports:
-    - protocol: TCP
-      port: 443
+    - to:
+      ports:
+        - protocol: TCP
+          port: 443
 
 {{/* Allow KIAM traffic by default. */}}
 ---
@@ -93,18 +93,77 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  - to:
-    - ipBlock:
-        cidr: 169.254.169.254/32
-    ports:
-    - protocol: TCP
-      port: 80
-
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 80
+{{- if not .Values.networkPolicy.AllowO11y.enabled }}
+{{/* Allow O11y traffic by default when DenyALL enabled */}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "{{ include "common.fullname" $root }}-allow-o11y"
+  namespace: {{ $root.Release.Namespace }}
+{{- with $root.Values.networkPolicy.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "common.labels.standard" $root | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "common.labels.standard" $root | indent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: o11y
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: grafana-k8s-monitoring
+{{- end }}
+{{/* End AllowO11y DenyALL */}}
 {{/* End DenyALL */}}
 {{- end }}
 
+{{- if .Values.networkPolicy.AllowO11y.enabled }}
+{{/* Allow O11y traffic with optional parameter */}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "{{ include "common.fullname" $root }}-allow-o11y"
+  namespace: {{ $root.Release.Namespace }}
+{{- with $root.Values.networkPolicy.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "common.labels.standard" $root | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "common.labels.standard" $root | indent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: o11y
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: grafana-k8s-monitoring
+{{- end }}
+{{/* End AllowO11y */}}
 {{/* Make a loop over all the INGRESS rules*/}}
 {{- if .Values.networkPolicy.Ingress }}
 {{- range $NetPolicy := .Values.networkPolicy.Ingress }}
@@ -125,37 +184,37 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-  {{- range $NPSelector, $NPValue := $NetPolicy.selector }}
-    {{- if eq $NPSelector "ipBlock" }}
-    - ipBlock:
-      {{- range $NetPolicy.selector.ipBlock }}
-        cidr: {{ . }}
+    - from:
+    {{- range $NPSelector, $NPValue := $NetPolicy.selector }}
+      {{- if eq $NPSelector "ipBlock" }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{ end }} ipBlock:
+        {{- range $NetPolicy.selector.ipBlock }}
+          cidr: {{ . }}
+        {{- end }}
       {{- end }}
-    {{- end }}
 
     {{- if eq $NPSelector "namespaceSelector" }}
       {{- range $key, $value := $NetPolicy.selector.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels:
-          {{ $key }}: {{ $value }}
-      {{- end }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{- end }} namespaceSelector:
+          matchLabels:
+            {{ $key }}: {{ $value }}
+        {{- end }}
     {{- end }}
 
     {{- if eq $NPSelector "podSelector" }}
       {{- range $key, $value := $NetPolicy.selector.podSelector }}
-    - podSelector:
-        matchLabels:
-          {{ $key }}: {{ $value }}
-      {{- end }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{- end }} podSelector:
+          matchLabels:
+            {{ $key }}: {{ $value }}
+        {{- end }}
     {{- end }}
   {{- end }}
-  - ports:
-    {{- range $NPports := $NetPolicy.ports }}
-    - {{- $NPports | toYaml | nindent 6 -}}
-    {{- end }}
+      {{- with $NetPolicy.ports }}
+      ports:
+        {{- $NetPolicy.ports | toYaml | nindent 8 }}
+      {{- end }}
 
 {{/* End Ingress */}}
 {{- end }}
@@ -182,37 +241,37 @@ spec:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  - to:
-  {{- range $NPSelector, $NPValue := $NetPolicy.selector }}
-    {{- if eq $NPSelector "ipBlock" }}
-    - ipBlock:
-      {{- range $NetPolicy.selector.ipBlock }}
-        cidr: {{ . }}
+    - to:
+    {{- range $NPSelector, $NPValue := $NetPolicy.selector }}
+      {{- if eq $NPSelector "ipBlock" }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{- end }} ipBlock:
+        {{- range $NetPolicy.selector.ipBlock }}
+          cidr: {{ . }}
+        {{- end }}
       {{- end }}
-    {{- end }}
 
-    {{- if eq $NPSelector "namespaceSelector" }}
-      {{- range $key, $value := $NetPolicy.selector.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels:
-          {{ $key }}: {{ $value }}
+      {{- if eq $NPSelector "namespaceSelector" }}
+        {{- range $key, $value := $NetPolicy.selector.namespaceSelector }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{- end }} namespaceSelector:
+          matchLabels:
+            {{ $key }}: {{ $value }}
+        {{- end }}
       {{- end }}
-    {{- end }}
 
-    {{- if eq $NPSelector "podSelector" }}
-      {{- range $key, $value := $NetPolicy.selector.podSelector }}
-    - podSelector:
-        matchLabels:
-          {{ $key }}: {{ $value }}
+      {{- if eq $NPSelector "podSelector" }}
+        {{- range $key, $value := $NetPolicy.selector.podSelector }}
+      {{ if not (eq $NetPolicy.selector.operator "And") -}}-{{- end }} podSelector:
+          matchLabels:
+            {{ $key }}: {{ $value }}
+        {{- end }}
       {{- end }}
-    {{- end }}
   {{- end }}
-  - ports:
-    {{- range $NPports := $NetPolicy.ports }}
-    - {{- $NPports | toYaml | nindent 6 -}}
-    {{- end }}
+      {{- with $NetPolicy.ports }}
+      ports:
+        {{- $NetPolicy.ports | toYaml | nindent 8 }}
+      {{- end }}
 
 {{/* End Egress */}}
 {{- end }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -630,7 +630,7 @@ IncludeForecastleEnv:
 
 
 # Networkpolices https://kubernetes.io/docs/concepts/services-networking/network-policies/
-# Spoton documentation https://github.com/vhs-spoton/personal-doc/blob/main/networkpolices.md
+# Spoton documentation https://docs.corp.spoton.sh/operations/kubernetes/network-policies/
 # If enable, will allow or deny input or output traffic to specific port/pod/namespace/cidr.
 networkPolicy:
   enabled: false
@@ -640,6 +640,10 @@ networkPolicy:
   # This will disable all the input/output traffic by default, except the DNS queries, TCP/443 and KIAM traffic (TCP/80 for 169.254.169.254).
   # Is recommendable to have it disabled at begin to make tests, but enable it on production.
   DenyALL:
+    enabled: false
+
+  # This will allow the traffic to the O11y service
+  AllowO11y:
     enabled: true
 
   # The input traffic rules. Each pod can have many input rules or a combination of they in one rule. Some examples:
@@ -650,7 +654,7 @@ networkPolicy:
   # Allow all traffic from everyone on port 443.
   # Allow all traffic from 8.8.8.8 on port 80 and 21
   # We can use 3 types of Selector ipBlock, namespaceSelector and podSelector, plus the ports (port and protocol)
-  # VERY IMPORTANT... using more than one selector will work as "OR" not like as "AND" in this template.
+  # VERY IMPORTANT... using more than one selector will work as "OR" unless you'll specify selector.operator: "And"
 
   # In the example above, we are allowing the input traffic from the IPs 8.8.8.8 OR 1.1.1.1 OR from namespace: staging
   # OR namespace: prod OR pods with the role "frontend" on the ports 5432/TCP and 123/UDP
@@ -683,6 +687,10 @@ networkPolicy:
 
   # # The EGRESS rules will filter all the output traffic and is than necesary like the ingress.
   Egress: {}
+  #   # To allow all egress traffic, you can leave empty map for selector of egress.
+  #   - name: allow-all-egress
+  #     selector: {}
+
   #   # In this example we are allowing traffic HTTP and HTTPS to all destinationes (not very good, but is ok)
   #   - name: http-and-https
   #     ports:


### PR DESCRIPTION
* fix rendering of `ports`
* add rules for o11y to default rules when `DenyALL` enabled
* add AllowO11y parameter to be able to enable o11y traffic without wondering about proper namespaces etc
* introduce `And` operator in selectors:
  * if `selector.operator` is not specified, it will be used as `Or` to keep backward compability