### PR TITLE
add optional extra annotations,

### DIFF
--- a/monochart/README.md
+++ b/monochart/README.md
@@ -38,6 +38,12 @@ If you need more than one InitContainer, you can use **extraInitContainer** para
 ### SealedSecrets
 [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) is a kubernetes controller that allows us to generate and encrypt secrets using TLS certificates (RSA 4096 bit by default) and not the default base64. With it, we can create secrets and manager/store it inside of the github repository.
 
+This requires the sealedsecrets controller to be installed in the cluster first. The component to install for eks clusters is this one: https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/eks/cluster-services/sealed-secrets.yaml
+
+For kops clusters, the right component to use is this one: https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/helm-sealed-secrets.yaml
+
+To make sure a secret gets created before pod creation, use the extraAnnotations provided in the google-secrets example in the values.yaml.
+
 To enable it on this chart you need to add this values to the helmfile.
 
 ```yaml
@@ -52,14 +58,30 @@ sealedsecrets:
 envFrom:
     secrets:
     - google-secrets
+
+VolumeMountsConfig: |
+  - name: google-secrets
+    secret:
+      defaultMode: 420
+      secretName: google-secrets
+
+FirstVolumeMounts: |
+  - mountPath: /google/secrets
+    name: google-secrets
 ```
 
 The first will create a **sealed secret** resource called google-secrets with two secrets (SECRET_NAME and ANOTHER_SECRET)... when deployed, kubernetes will use the private key to decipher this secrets and get the correct value.
 
 The second, will setup this secret inside of the containers.
 
+The third and fourth, will set up a volume using a volume mount, that will create a file inside of the pod for each secret defined under encryped_data. (using this example, we should get a file named SECRET_NAME with the unencrypted data as the content, and same for ANOTHER_SECRET. )
+
 > Note: To generate you can use [kubeseal](https://github.com/bitnami-labs/sealed-secrets#installation-from-source) from CLI or you can use the Spoton [WebSeal](https://webseal.qa.spoton.sh/) interface.
 
+An example of using kubeseal: (The sealedsecret.pub cert is obtained in the logs of the sealedsecrets controller)
+```
+kubeseal --cert sealedsecret.pub --scope cluster-wide --format yaml <unencrypted-secret.yaml >sealed-secret.yaml
+```
 
 ### VolumeMounts
 The actual VolumeMounts of the old-monochart version works, but not very well when we need to manage it with differents containers (ex: InitContainers). so, we have add 3 new parameters to improve it

--- a/monochart/README.md
+++ b/monochart/README.md
@@ -74,7 +74,7 @@ The first will create a **sealed secret** resource called google-secrets with tw
 
 The second, will setup this secret inside of the containers.
 
-The third and fourth, will set up a volume using a volume mount, that will create a file inside of the pod for each secret defined under encryped_data. (using this example, we should get a file named SECRET_NAME with the unencrypted data as the content, and same for ANOTHER_SECRET. )
+The third and fourth, will set up a volume using a volume mount, that will create a file inside of the pod for each secret defined under encrypedData. (using this example, we should get a file named SECRET_NAME with the unencrypted data as the content, and same for ANOTHER_SECRET. )
 
 > Note: To generate you can use [kubeseal](https://github.com/bitnami-labs/sealed-secrets#installation-from-source) from CLI or you can use the Spoton [WebSeal](https://webseal.qa.spoton.sh/) interface.
 

--- a/monochart/templates/sealedsecrets.yaml
+++ b/monochart/templates/sealedsecrets.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ $SealedSecret.name }}
   annotations:
     sealedsecrets.bitnami.com/cluster-wide: "true"
+    {{- range $key, $value := $SealedSecret.extraAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     {{- include "common.labels.standard" $root | nindent 4 }}
 spec:
@@ -16,6 +19,9 @@ spec:
       name: {{ $SealedSecret.name }}
       annotations:
         sealedsecrets.bitnami.com/cluster-wide: "true"
+        {{- range $key, $value := $SealedSecret.extraAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels:
         {{- include "common.labels.standard" $root | nindent 8 }}
     type: Opaque

--- a/monochart/values.example.yaml
+++ b/monochart/values.example.yaml
@@ -47,33 +47,6 @@ secrets:
       secret.test.txt: |-
         some text
 
-# SealedSecrets resouces
-# Basically we need to add a name to the resource and all the secrets/values that we want.
-# the secret name can be changed without problem, but the resource name or the value *NO*
-# To create a sealedsecrets you can use the webseal or https://webseal.qa.spoton.sh/
-# This requires the sealedsecrets controller to be installed in the cluster first. See https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/eks/cluster-services/sealed-secrets.yaml
-# To create a sealedsecret in a different cluster, you can use the kubeseal command line tool with the public key of the cluster. (This is outputed in the logs of the sealedsecrets controller)
-#   Following this, you can get the encrypted data using: (cluster-wide is important here, monochart expects a cluster-wide secret for easier sealedsecret management)
-#     kubeseal --cert sealedsecret.pub --scope cluster-wide --format yaml <unencrypted-secret.yaml >sealed-secret.yaml
-# To make sure a secret gets created before pod creation, use the extraAnnotations provided in the google-secrets example
-# NOTE: remember to add the sealedsecret name to the "envFrom.secrets" above.
-sealedsecrets:
-  enabled: false
-  # keys:
-  #   - name: google-secrets
-  #     extraAnnotations:
-  #       "helm.sh/hook-weight": "1"
-  #       "helm.sh/hook": "pre-install,pre-upgrade"
-  #       "helm.sh/hook-delete-policy": "before-hook-creation"
-  #     encryptedData:
-  #       SECRET_NAME: AgSDSDSB7oTOgJdtURoUrZ7IDuC50xdfdEMWFwAeashNXnM+s+QcdAXc2Bp99uD2RKYjCvdkP/+OzLmF0SqVfqjPM/+toplTMgNSDQSXGKZMQmrn+fXeq61qXqj2vQ/2tz/98DYXDQXJK3LPpCT/bXJ0Zv6jjxBkONOqkko//PWDxDk/zqVM75MH5qhy8K5Ds9YpQ3aWCtHuRXe1365fQPDpl+hJGZZpC1NZbQFUWpNrXOLQrMRXP8fOZ3+VWo0+elebPE9OpxoWuYXQHX4Dn8B7ArNp6XPJbbxBgsKNv9pG7VHNDRH98kUbttfOMJjIYF0d2IoiAPA9mwSsY3S7Jn0/dp8PL9WgNiILaVDWihs9nhg/iJZvPD8mymNZOggQH8gGkMQQ8p+rgWKeenTwHpC0gfZjQ73OyLuSKhYHn0tvmloiDq0dDreoZCiahZEfZ3MGaOD7xqj8qHmsHxzaDlilBLiM0X1XOmSVxs1Nvmka6vAQEzX6fesyAmPfKqdPEPGpjn39lkWKOHJqby3UnAyjNeTkCvjc4hwQwzNmjivyrbskQGwj3XxpVZruD9XHDRgMca/r3T9NVIpng0yVEmA6HKVOLupUMHvHsY4rE+2n5du/NmBaaw3lM5MybnhxIDQGQz8bFhxr5iIM9vBhF+zRz0ahtAULODh0+ebVHrCbQQnK3EzrkQzxqu6EPPIsuPQepcdeCAmNnoS0/JC2xC1rmEz
-  #       ANOTHER_SECRET: AgCSDSDSNXUuenZ8asasFeVEOG+BTH9AdfdfdzbqYcz9VK2GIJdXgnInUv/N7wnIz77yjMd52qXV9SuNJo9RIJwJ+ioo0PuTYBT2ueApCras6hRMtey1fx0shjNJZjYv6uVWsmdd+Y17BTeeB7J6wo0spv/GfnHrtrTn2AfMxV/M2brSxG4yQ6gsrUNEdhdHcII47ae7DDqjEJ2UZgVdRCv8o8AKCu/NqiPEJklLvcXUigKc7KNyGVoJX9uFWGl4buu7hs5IpKfj58tbi6+8yW5YW3PyVbkydIxVAZrGRZS5G60jbCc7UGmo3fuWI7YBZtbsWw8alBexOX/U6+CDMRGClqdick5GGM0cGXHfsSM1XTMQBMxuWTzvEO2RnrgiRZ57PcBh5xrvBRQu49LhZAukPvLj2x6P2jrhU7xrjO+YI1kSZow7tuiIQNZuR+CKNxpZuNUqYvci3jRbj3Pxg0W9AkntTouFxyd4O02yz+OP25Zfqa+F1Uu/JZ9Zkph1/vykixCRc3sEx2oDXjQKFoNFnbCfi7vhNsZNfnLc/jOhXoMOrd63ZR+37cAXyiZ/6GxzWSYygb1CaR9PtALWvkThbgEYRGWdMVKVqyk6Br7K8gyodMNx1/QAX0/Qd9ykAMVoFhC6ykrVvkdPG2n65Ftx0jLrPQ3U75bijffl7e0UvA4olhBxtmgSMymAmKrCs59EqXhAfBcOdaUOwSguyZAJuJ3Wza9eJWFQ==
-
-  #   - name: aws-s3
-  #     encryptedData:
-  #       USER_ADMIN: sfhiewhiewnfilblfiabflisafblisafalifaifnakfs....
-  #       PASS_ADMIN: dfasifnaisnaisdnbafsbasfbsaif...
-
 # Inline ENV variables
 env:
   INLINE_ENV_NAME: ENV_VALUE

--- a/monochart/values.example.yaml
+++ b/monochart/values.example.yaml
@@ -47,6 +47,33 @@ secrets:
       secret.test.txt: |-
         some text
 
+# SealedSecrets resouces
+# Basically we need to add a name to the resource and all the secrets/values that we want.
+# the secret name can be changed without problem, but the resource name or the value *NO*
+# To create a sealedsecrets you can use the webseal or https://webseal.qa.spoton.sh/
+# This requires the sealedsecrets controller to be installed in the cluster first. See https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/eks/cluster-services/sealed-secrets.yaml
+# To create a sealedsecret in a different cluster, you can use the kubeseal command line tool with the public key of the cluster. (This is outputed in the logs of the sealedsecrets controller)
+#   Following this, you can get the encrypted data using: (cluster-wide is important here, monochart expects a cluster-wide secret for easier sealedsecret management)
+#     kubeseal --cert sealedsecret.pub --scope cluster-wide --format yaml <unencrypted-secret.yaml >sealed-secret.yaml
+# To make sure a secret gets created before pod creation, use the extraAnnotations provided in the google-secrets example
+# NOTE: remember to add the sealedsecret name to the "envFrom.secrets" above.
+sealedsecrets:
+  enabled: false
+  # keys:
+  #   - name: google-secrets
+  #     extraAnnotations:
+  #       "helm.sh/hook-weight": "1"
+  #       "helm.sh/hook": "pre-install,pre-upgrade"
+  #       "helm.sh/hook-delete-policy": "before-hook-creation"
+  #     encryptedData:
+  #       SECRET_NAME: AgSDSDSB7oTOgJdtURoUrZ7IDuC50xdfdEMWFwAeashNXnM+s+QcdAXc2Bp99uD2RKYjCvdkP/+OzLmF0SqVfqjPM/+toplTMgNSDQSXGKZMQmrn+fXeq61qXqj2vQ/2tz/98DYXDQXJK3LPpCT/bXJ0Zv6jjxBkONOqkko//PWDxDk/zqVM75MH5qhy8K5Ds9YpQ3aWCtHuRXe1365fQPDpl+hJGZZpC1NZbQFUWpNrXOLQrMRXP8fOZ3+VWo0+elebPE9OpxoWuYXQHX4Dn8B7ArNp6XPJbbxBgsKNv9pG7VHNDRH98kUbttfOMJjIYF0d2IoiAPA9mwSsY3S7Jn0/dp8PL9WgNiILaVDWihs9nhg/iJZvPD8mymNZOggQH8gGkMQQ8p+rgWKeenTwHpC0gfZjQ73OyLuSKhYHn0tvmloiDq0dDreoZCiahZEfZ3MGaOD7xqj8qHmsHxzaDlilBLiM0X1XOmSVxs1Nvmka6vAQEzX6fesyAmPfKqdPEPGpjn39lkWKOHJqby3UnAyjNeTkCvjc4hwQwzNmjivyrbskQGwj3XxpVZruD9XHDRgMca/r3T9NVIpng0yVEmA6HKVOLupUMHvHsY4rE+2n5du/NmBaaw3lM5MybnhxIDQGQz8bFhxr5iIM9vBhF+zRz0ahtAULODh0+ebVHrCbQQnK3EzrkQzxqu6EPPIsuPQepcdeCAmNnoS0/JC2xC1rmEz
+  #       ANOTHER_SECRET: AgCSDSDSNXUuenZ8asasFeVEOG+BTH9AdfdfdzbqYcz9VK2GIJdXgnInUv/N7wnIz77yjMd52qXV9SuNJo9RIJwJ+ioo0PuTYBT2ueApCras6hRMtey1fx0shjNJZjYv6uVWsmdd+Y17BTeeB7J6wo0spv/GfnHrtrTn2AfMxV/M2brSxG4yQ6gsrUNEdhdHcII47ae7DDqjEJ2UZgVdRCv8o8AKCu/NqiPEJklLvcXUigKc7KNyGVoJX9uFWGl4buu7hs5IpKfj58tbi6+8yW5YW3PyVbkydIxVAZrGRZS5G60jbCc7UGmo3fuWI7YBZtbsWw8alBexOX/U6+CDMRGClqdick5GGM0cGXHfsSM1XTMQBMxuWTzvEO2RnrgiRZ57PcBh5xrvBRQu49LhZAukPvLj2x6P2jrhU7xrjO+YI1kSZow7tuiIQNZuR+CKNxpZuNUqYvci3jRbj3Pxg0W9AkntTouFxyd4O02yz+OP25Zfqa+F1Uu/JZ9Zkph1/vykixCRc3sEx2oDXjQKFoNFnbCfi7vhNsZNfnLc/jOhXoMOrd63ZR+37cAXyiZ/6GxzWSYygb1CaR9PtALWvkThbgEYRGWdMVKVqyk6Br7K8gyodMNx1/QAX0/Qd9ykAMVoFhC6ykrVvkdPG2n65Ftx0jLrPQ3U75bijffl7e0UvA4olhBxtmgSMymAmKrCs59EqXhAfBcOdaUOwSguyZAJuJ3Wza9eJWFQ==
+
+  #   - name: aws-s3
+  #     encryptedData:
+  #       USER_ADMIN: sfhiewhiewnfilblfiabflisafblisafalifaifnakfs....
+  #       PASS_ADMIN: dfasifnaisnaisdnbafsbasfbsaif...
+
 # Inline ENV variables
 env:
   INLINE_ENV_NAME: ENV_VALUE

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -92,10 +92,6 @@ secrets: {}
 # Basically we need to add a name to the resource and all the secrets/values that we want.
 # the secret name can be changed without problem, but the resource name or the value *NO*
 # To create a sealedsecrets you can use the webseal or https://webseal.qa.spoton.sh/
-# This requires the sealedsecrets controller to be installed in the cluster first. See https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/eks/cluster-services/sealed-secrets.yaml
-# To create a sealedsecret in a different cluster, you can use the kubeseal command line tool with the public key of the cluster. (This is outputed in the logs of the sealedsecrets controller)
-#   Following this, you can get the encrypted data using: (cluster-wide is important here, monochart expects a cluster-wide secret for easier sealedsecret management)
-#     kubeseal --cert sealedsecret.pub --scope cluster-wide --format yaml <unencrypted-secret.yaml >sealed-secret.yaml
 # To make sure a secret gets created before pod creation, use the extraAnnotations provided in the google-secrets example
 # NOTE: remember to add the sealedsecret name to the "envFrom.secrets" above.
 sealedsecrets:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -91,12 +91,21 @@ secrets: {}
 # SealedSecrets resouces
 # Basically we need to add a name to the resource and all the secrets/values that we want.
 # the secret name can be changed without problem, but the resource name or the value *NO*
-# to create a sealedsecrets you can use the webseal or https://webseal.qa.spoton.sh/
+# To create a sealedsecrets you can use the webseal or https://webseal.qa.spoton.sh/
+# This requires the sealedsecrets controller to be installed in the cluster first. See https://github.com/SpotOnInc/infrastructure/blob/main/stacks/catalog/eks/cluster-services/sealed-secrets.yaml
+# To create a sealedsecret in a different cluster, you can use the kubeseal command line tool with the public key of the cluster. (This is outputed in the logs of the sealedsecrets controller)
+#   Following this, you can get the encrypted data using: (cluster-wide is important here, monochart expects a cluster-wide secret for easier sealedsecret management)
+#     kubeseal --cert sealedsecret.pub --scope cluster-wide --format yaml <unencrypted-secret.yaml >sealed-secret.yaml
+# To make sure a secret gets created before pod creation, use the extraAnnotations provided in the google-secrets example
 # NOTE: remember to add the sealedsecret name to the "envFrom.secrets" above.
 sealedsecrets:
   enabled: false
   # keys:
   #   - name: google-secrets
+  #     extraAnnotations:
+  #       "helm.sh/hook-weight": "1"
+  #       "helm.sh/hook": "pre-install,pre-upgrade"
+  #       "helm.sh/hook-delete-policy": "before-hook-creation"
   #     encryptedData:
   #       SECRET_NAME: AgSDSDSB7oTOgJdtURoUrZ7IDuC50xdfdEMWFwAeashNXnM+s+QcdAXc2Bp99uD2RKYjCvdkP/+OzLmF0SqVfqjPM/+toplTMgNSDQSXGKZMQmrn+fXeq61qXqj2vQ/2tz/98DYXDQXJK3LPpCT/bXJ0Zv6jjxBkONOqkko//PWDxDk/zqVM75MH5qhy8K5Ds9YpQ3aWCtHuRXe1365fQPDpl+hJGZZpC1NZbQFUWpNrXOLQrMRXP8fOZ3+VWo0+elebPE9OpxoWuYXQHX4Dn8B7ArNp6XPJbbxBgsKNv9pG7VHNDRH98kUbttfOMJjIYF0d2IoiAPA9mwSsY3S7Jn0/dp8PL9WgNiILaVDWihs9nhg/iJZvPD8mymNZOggQH8gGkMQQ8p+rgWKeenTwHpC0gfZjQ73OyLuSKhYHn0tvmloiDq0dDreoZCiahZEfZ3MGaOD7xqj8qHmsHxzaDlilBLiM0X1XOmSVxs1Nvmka6vAQEzX6fesyAmPfKqdPEPGpjn39lkWKOHJqby3UnAyjNeTkCvjc4hwQwzNmjivyrbskQGwj3XxpVZruD9XHDRgMca/r3T9NVIpng0yVEmA6HKVOLupUMHvHsY4rE+2n5du/NmBaaw3lM5MybnhxIDQGQz8bFhxr5iIM9vBhF+zRz0ahtAULODh0+ebVHrCbQQnK3EzrkQzxqu6EPPIsuPQepcdeCAmNnoS0/JC2xC1rmEz
   #       ANOTHER_SECRET: AgCSDSDSNXUuenZ8asasFeVEOG+BTH9AdfdfdzbqYcz9VK2GIJdXgnInUv/N7wnIz77yjMd52qXV9SuNJo9RIJwJ+ioo0PuTYBT2ueApCras6hRMtey1fx0shjNJZjYv6uVWsmdd+Y17BTeeB7J6wo0spv/GfnHrtrTn2AfMxV/M2brSxG4yQ6gsrUNEdhdHcII47ae7DDqjEJ2UZgVdRCv8o8AKCu/NqiPEJklLvcXUigKc7KNyGVoJX9uFWGl4buu7hs5IpKfj58tbi6+8yW5YW3PyVbkydIxVAZrGRZS5G60jbCc7UGmo3fuWI7YBZtbsWw8alBexOX/U6+CDMRGClqdick5GGM0cGXHfsSM1XTMQBMxuWTzvEO2RnrgiRZ57PcBh5xrvBRQu49LhZAukPvLj2x6P2jrhU7xrjO+YI1kSZow7tuiIQNZuR+CKNxpZuNUqYvci3jRbj3Pxg0W9AkntTouFxyd4O02yz+OP25Zfqa+F1Uu/JZ9Zkph1/vykixCRc3sEx2oDXjQKFoNFnbCfi7vhNsZNfnLc/jOhXoMOrd63ZR+37cAXyiZ/6GxzWSYygb1CaR9PtALWvkThbgEYRGWdMVKVqyk6Br7K8gyodMNx1/QAX0/Qd9ykAMVoFhC6ykrVvkdPG2n65Ftx0jLrPQ3U75bijffl7e0UvA4olhBxtmgSMymAmKrCs59EqXhAfBcOdaUOwSguyZAJuJ3Wza9eJWFQ==


### PR DESCRIPTION
add optional extra annotations, can be used when secret has to be created before pod is created

this was needed for use when a pod is mounting a secret as a volumemount

```
        VolumeMountsConfig: |
          - name: admin-api-files-config
            configMap:
              name: admin-api-files-config
          - name: connect-certs-and-keys
            secret:
              defaultMode: 420
              secretName: connect-certs-and-keys

        FirstVolumeMounts: |
          - mountPath: /appetize/certs
            name: connect-certs-and-keys
```

without the helm annotations to tell helm to apply the sealed secret before pod creation, we get this error:
```
Events:
  Type     Reason       Age                From               Message
  ----     ------       ----               ----               -------
  Normal   Scheduled    42s                default-scheduler  Successfully assigned admin/admin-api-668884fc4-txgk8 to ip-10-117-5-134.us-west-2.compute.internal
  Warning  FailedMount  10s (x7 over 42s)  kubelet            MountVolume.SetUp failed for volume "connect-certs-and-keys" : secret "connect-certs-and-keys" not found
```

so we can easily fix this by adding some flexibility to this template to allow for more annotations, while keeping the static "cluster-wide" annotation, to keep sealed secretmanagement easy


this was tested by making this prerelease target a test branch and it worked: https://github.com/SpotOnEnterprise/admin/actions/runs/12516396782
```
repositories:
  - name: "spoton-helmcharts"
    url: "git+https://github.com/SpotOnInc/helmcharts@monochart?ref=DEV-8442-admin-services-connnect-certs-and-keys-sealed-secret"
```

once this PR is merged I can make the same change to connect and other apps that use secrets the same way.
