### PR TITLE
feat: Allow configurable backoffLimit for jobs

### DIFF
--- a/monochart/templates/job.yaml
+++ b/monochart/templates/job.yaml
@@ -17,6 +17,7 @@ metadata:
 {{- end }}
 spec:
   activeDeadlineSeconds: {{ default 300 $job.activeDeadlineSeconds }}
+  backoffLimit: {{ default 6 $job.backoffLimit }}
   ttlSecondsAfterFinished:  {{ default 600 $job.ttlSecondsAfterFinished }}
   template:
     metadata:

--- a/monochart/values.example.yaml
+++ b/monochart/values.example.yaml
@@ -106,3 +106,17 @@ deployment:
             values:
             - "{{ requiredEnv "RELEASE_NAME" }}-postgresql"
         topologyKey: "kubernetes.io/hostname"
+
+job:
+  default:
+    enabled: true
+    activeDeadlineSeconds: 150
+    backoffLimit: 1
+    restartPolicy: Never
+    ttlSecondsAfterFinished: 150
+    pod:
+      annotations: {}
+        #"iam.amazonaws.com/role": 'app-role'
+      labels: {}
+      # command:
+      args: []


### PR DESCRIPTION
Allow configurable backoffLimit for jobs. As unspecified today, the default is 6.