### PR TITLE
Pass root to funcs called in amb filter policy

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.29
+version: 1.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -6,14 +6,14 @@
 apiVersion: getambassador.io/v3alpha1
 kind: FilterPolicy
 metadata:
-  name: {{ include "common.fullname" . }}-{{ $name }}
+  name: {{ include "common.fullname" $root }}-{{ $name }}
   namespace: ambassador
 {{- with $filterPolicy.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "common.labels.standard" $root | indent 4 }}
 {{- with $filterPolicy.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}

--- a/monochart/templates/ambassador-filter.yaml
+++ b/monochart/templates/ambassador-filter.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "common.labels.standard" $root | indent 4 }}
 {{- with $filter.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}


### PR DESCRIPTION
Fix the Filter and FilterPolicy templates to pass the correct context to templating functions.  Inside of a `range` statement, passing `.` passes the context inside of the range, instead of the root context.