### PR TITLE
Bugfix/filter policy naming

### DIFF
--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -20,14 +20,14 @@ metadata:
 spec:
   rules:
     {{- range $path := $filterPolicy.excludePaths }}
-    - host: {{ include "common.name" $root }}.{{ $.Values.ambassador.tld }}
+    - host: {{ include "common.fullname" $root }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
         - name: ambassador-okta-central-filter
           namespace: ambassador
           onDeny: continue
           onAllow: break
-        - name: ambassador-{{ include "common.name" $root }}-{{ $.Release.Namespace }}-okta-sso-filter
+        - name: ambassador-{{ include "common.fullname" $root }}-{{ $.Release.Namespace }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
 {{- end -}}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -20,14 +20,14 @@ metadata:
 spec:
   rules:
     {{- range $path := $filterPolicy.excludePaths }}
-    - host: {{ include "common.fullname" $root }}.{{ $.Release.Namespace }}.{{ $.Values.ambassador.tld }}
+    - host: {{ include "common.name" $root }}.{{ $.Release.Namespace }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
         - name: ambassador-okta-central-filter
           namespace: ambassador
           onDeny: continue
           onAllow: break
-        - name: ambassador-{{ include "common.fullname" $root }}-{{ $.Release.Namespace }}-okta-sso-filter
+        - name: ambassador-{{ include "common.name" $root }}-{{ $.Release.Namespace }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
 {{- end -}}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   rules:
     {{- range $path := $filterPolicy.excludePaths }}
-    - host: {{ include "common.name" $root }}.{{ $.Release.Namespace }}.{{ $.Values.ambassador.tld }}
+    - host: {{ include "common.name" $root }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
         - name: ambassador-okta-central-filter

--- a/monochart/templates/ambassador-filter.yaml
+++ b/monochart/templates/ambassador-filter.yaml
@@ -28,7 +28,7 @@ spec:
     clientSessionMaxIdle: 0s
     grantType: '""'
     protectedOrigins:
-    - origin: https://{{ include "common.fullname" $root }}.{{ $.Release.Namespace }}.{{ $.Values.ambassador.tld }}
+    - origin: https://{{ include "common.fullname" $root }}.{{ $.Values.ambassador.tld }}
     secretName: ambassador-oauth2-client-secret
     secretNamespace: ambassador
 {{- end -}}


### PR DESCRIPTION
The DNS hostname being constructed contains the FLAVOR twice.  This changes hostnames from and invalid DNS:
`express-item-service.express-prod-c1.express-prod-c1.express.spoton.com`
...to a valid DNS hostname:
`express-item-service.express-prod-c1.express.spoton.com`.

