### PR TITLE
Feature/override dns name

### DIFF
--- a/monochart/templates/ambassador-filter.yaml
+++ b/monochart/templates/ambassador-filter.yaml
@@ -3,8 +3,8 @@
 {{- range $name, $filter := .Values.ambassador.filters -}}
 {{- if $filter.enabled }}
 {{- $dnsName := include "common.fullname" $root -}}
-{{- if $filterPolicy.dnsNameOverride -}}
-{{-   $dnsName = $filterPolicy.dnsNameOverride -}}
+{{- if $filter.dnsNameOverride -}}
+{{-   $dnsName = $filter.dnsNameOverride -}}
 {{- end -}}
 ---
 apiVersion: getambassador.io/v3alpha1

--- a/monochart/values.example.yaml
+++ b/monochart/values.example.yaml
@@ -120,3 +120,31 @@ job:
       labels: {}
       # command:
       args: []
+
+filters:
+  user-auth:
+    enabled: false
+    clientID: "0oa9jntm09fFIJlPJ697"
+    # annotations:
+    #   description: "OAuth2 filter for user authentication"
+    # labels:
+    #   environment: "nonprod"
+    #   team: "backend"
+    dnsNameOverride: item-availability
+
+filterPolicies:
+  general-policy:
+    enabled: false
+    excludePaths: # standard set of exclude paths most filterPolicies use
+      - /docs*
+      - /health*
+      - /heartbeat*
+      - /metrics*
+      - /version*
+      - /openapi.json*
+    # annotations:
+    #   description: "Paths to exclude from authentication"
+    # labels:
+    #   environment: "staging"
+    #   team: "myteam"
+    dnsNameOverride: item-availability

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -354,6 +354,8 @@ ambassador:
       # labels:
       #   environment: "nonprod"
       #   team: "backend"
+      ## If the DNS name is "app-alias.TLD", different from "appName", override the hostname.  (TLD stays the same)
+      # dnsNameOverride: app-alias
 # https://www.getambassador.io/docs/edge-stack/latest/topics/using/filters
   filterPolicies:
     general-policy:
@@ -365,12 +367,14 @@ ambassador:
         - /metrics*
         - /version*
         - /openapi.json*
-        - '*'
       # annotations:
       #   description: "Paths to exclude from authentication"
       # labels:
       #   environment: "staging"
       #   team: "myteam"
+      ## If the DNS name is "app-alias.TLD", different from "appName", override the hostname.  (TLD stays the same)
+      ## Must also be a dnsNameOverride in the filters section above to make them match!
+      # dnsNameOverride: app-alias
 
 ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md


### PR DESCRIPTION
There is one helm chart which creates a DNS hostname that does not match the name of the repo.  When creating Filter and FilterPolicy, this provides a way to override that dns hostname in the catalog files.

Updated the values.yaml and values.example.yaml with examples.