### PR TITLE
Prep filter policies for express cells

### DIFF
--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -31,7 +31,21 @@ spec:
           namespace: ambassador
           onDeny: continue
           onAllow: break
-        - name: ambassador-{{ include "common.fullname" $root }}-{{ $.Release.Namespace }}-okta-sso-filter
+        - name: {{ $dnsName }}-okta-sso-filter
+          namespace: ambassador
+    {{- end }}
+    {{- if $filterPolicy.merchantFilter }}
+    - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
+      path: "*"
+      filters:
+        - name: okta-merchant-filter
+          namespace: ambassador
+    {{- end }}
+    {{- if $filterPolicy.centralFilter }}
+    - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
+      path: "*"
+      filters:
+        - name: okta-central-filter
           namespace: ambassador
     {{- end }}
 {{- end -}}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -34,14 +34,14 @@ spec:
         - name: {{ $dnsName }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.merchantFilter }}
+    {{- if $filterPolicy.merchantFilter.enabled }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:
         - name: okta-merchant-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.centralFilter }}
+    {{- if $filterPolicy.centralFilter.enabled }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -34,14 +34,14 @@ spec:
         - name: {{ $dnsName }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.merchantFilter.enabled }}
+    {{- if (($filterPolicy.merchantFilter).enabled) }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:
         - name: okta-merchant-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.centralFilter.enabled }}
+    {{- if (($filterPolicy.centralFilter).enabled) }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -367,6 +367,10 @@ ambassador:
         - /metrics*
         - /version*
         - /openapi.json*
+    merchantFilter:
+      enabled: false
+    centralFilter:
+      enabled: false
       # annotations:
       #   description: "Paths to exclude from authentication"
       # labels:


### PR DESCRIPTION
fix filter name used by exclude path rules & add optional merchant and central wildcard path rules

filter names should match what filters are deployed. additionally; some filters use a wildcard path with the central or merchant filters.