### PR TITLE
Fix template for filter policies

### DIFF
--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ $dnsName }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
-    {{- if (($filterPolicy.merchantFilter).enabled }}
+    {{- if (($filterPolicy.merchantFilter).enabled) }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -34,14 +34,14 @@ spec:
         - name: {{ $dnsName }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.merchantFilter.enabled }}
+    {{- if (($filterPolicy.merchantFilter).enabled }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:
         - name: okta-merchant-filter
           namespace: ambassador
     {{- end }}
-    {{- if $filterPolicy.centralFilter.enabled }}
+    {{- if (($filterPolicy.centralFilter).enabled) }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -27,21 +27,21 @@ spec:
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
-        - name: ambassador-okta-central-filter
+        - name: okta-central-filter
           namespace: ambassador
           onDeny: continue
           onAllow: break
         - name: {{ $dnsName }}-okta-sso-filter
           namespace: ambassador
     {{- end }}
-    {{- if (($filterPolicy.merchantFilter).enabled) }}
+    {{- if $filterPolicy.merchantFilter.enabled }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:
         - name: okta-merchant-filter
           namespace: ambassador
     {{- end }}
-    {{- if (($filterPolicy.centralFilter).enabled) }}
+    {{- if $filterPolicy.centralFilter.enabled }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: "*"
       filters:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -367,10 +367,10 @@ ambassador:
         - /metrics*
         - /version*
         - /openapi.json*
-    merchantFilter:
-      enabled: false
-    centralFilter:
-      enabled: false
+      merchantFilter:
+        enabled: false
+      centralFilter:
+        enabled: false
       # annotations:
       #   description: "Paths to exclude from authentication"
       # labels:


### PR DESCRIPTION
fixed filter references for excludePaths filters
Correct defaults

Testing:

rendering snippet with general policies enabled and central filter enabled.
```
 √ . [spoton-gbl-identity] (HOST) monochart ⨠ helm template . -f values.yaml
 ...
    - host: release-name-spoton-monochart.express-nonprod-c1.spoton.sh
      path: "/openapi.json*"
      filters:
        - name: okta-central-filter
          namespace: ambassador
          onDeny: continue
          onAllow: break
        - name: release-name-spoton-monochart-okta-sso-filter
          namespace: ambassador
    - host: release-name-spoton-monochart.express-nonprod-c1.spoton.sh
      path: "*"
      filters:
        - name: okta-central-filter
          namespace: ambassador
```

rendering snippet with filter policies values removed completely:

```
 √ . [spoton-gbl-identity] (HOST) monochart ⨠ helm template . -f values.yaml
---
# Source: spoton-monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment

metadata:
  name: release-name-spoton-monochart
  namespace: default
  labels:
    app.kubernetes.io/name: spoton-monochart
    helm.sh/chart: spoton-monochart-1.1.30
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    # https://github.com/vhs-spoton/personal-doc/blob/main/networkpolices.md
    spoton.NetPolicy: disabled
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: spoton-monochart
      app.kubernetes.io/instance: release-name
  revisionHistoryLimit: 10
  minReadySeconds: 0
  template:
    metadata:
      name: release-name-spoton-monochart
      annotations:
        # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
        checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
        checksum/secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

      labels:
        app.kubernetes.io/name: spoton-monochart
        helm.sh/chart: spoton-monochart-1.1.30
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        serve: "true"


    spec:
      serviceAccountName: default
      terminationGracePeriodSeconds: 30


      containers:
      - name: release-name
        image: "scratch:latest"
        imagePullPolicy: IfNotPresent


        env:


        ports:

        volumeMounts:

        resources:
          requests:
            cpu: 100m
            memory: 256Mi
      imagePullSecrets:
      volumes:
```

test rendering with monochart-testing repo:
```
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /actuator/info*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: '*'
```
compared to dc28:
```
 - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ambassador-apigateway-okta-central-filter
      namespace: ambassador-apigateway
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: ambassador-apigateway-kitchen-manager-service-express-uw2-01-okta-sso-filter
      namespace: ambassador-apigateway
    host: kitchen-manager-service.express-uw2-01.express.spoton.com
    path: /actuator/info*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ambassador-apigateway-okta-central-filter
      namespace: ambassador-apigateway
    host: kitchen-manager-service.express-uw2-01.express.spoton.com
    path: '*'
```