### PR TITLE
Allow custom filter rules for the excludePaths range

### DIFF
--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -27,11 +27,22 @@ spec:
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
-        {{- range $filter := $filterPolicy.customExcludePathFilters }}
-        - name: {{ quote $filter.name | default "okta-central-filter" }}
-          namespace: {{ $filter.namespace | default "ambassador" }}
-          onDeny: {{ $filter.onDeny | default "continue" }}
-          onAllow: {{ $filter.onAllow | default "break" }}
+        {{- if $filterPolicy.customExcludePathFilters }}
+          {{- range $filter := $filterPolicy.customExcludePathFilters }}
+          - name: {{ quote $filter.name }}
+            namespace: {{ $filter.namespace | default "ambassador" }}
+            onDeny: {{ $filter.onDeny | default "continue" }}
+            {{- if $filter.onAllow }}
+            onAllow: {{ $filter.onAllow }}
+            {{- end }}
+          {{- end }}
+        {{- else }}
+        - name: okta-central-filter
+          namespace: ambassador
+          onDeny: continue
+          onAllow: break
+        - name: {{ $dnsName }}-okta-sso-filter
+          namespace: ambassador
         {{- end }}
     {{- end }}
     {{- if (($filterPolicy.merchantFilter).enabled) }}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -27,12 +27,12 @@ spec:
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}
       path: {{ quote $path }}
       filters:
-        - name: okta-central-filter
-          namespace: ambassador
-          onDeny: continue
-          onAllow: break
-        - name: {{ $dnsName }}-okta-sso-filter
-          namespace: ambassador
+        {{- range $filter := $filterPolicy.customExcludePathFilters }}
+        - name: {{ $filter.name | default "okta-central-filter" }}
+          namespace: {{ $filter.namespace | default "ambassador" }}
+          onDeny: {{ $filter.onDeny | default "continue" }}
+          onAllow: {{ $filter.onAllow | default "break" }}
+        {{- end }}
     {{- end }}
     {{- if (($filterPolicy.merchantFilter).enabled) }}
     - host: {{ $dnsName }}.{{ $.Values.ambassador.tld }}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -28,7 +28,7 @@ spec:
       path: {{ quote $path }}
       filters:
         {{- range $filter := $filterPolicy.customExcludePathFilters }}
-        - name: {{ $filter.name | default "okta-central-filter" }}
+        - name: {{ quote $filter.name | default "okta-central-filter" }}
           namespace: {{ $filter.namespace | default "ambassador" }}
           onDeny: {{ $filter.onDeny | default "continue" }}
           onAllow: {{ $filter.onAllow | default "break" }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -367,6 +367,10 @@ ambassador:
         - /metrics*
         - /version*
         - /openapi.json*
+      customExcludePathFilters:
+        - name: ""
+          namespace: ambassador
+          onDeny: continue
       merchantFilter:
         enabled: false
       centralFilter:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -367,10 +367,11 @@ ambassador:
         - /metrics*
         - /version*
         - /openapi.json*
-      customExcludePathFilters:
-        - name: ""
-          namespace: ambassador
-          onDeny: continue
+      # use customExcludePathFilters if paths are different from the default use case
+      # customExcludePathFilters:
+      #   - name: ""
+      #     namespace: ambassador
+      #     onDeny: continue
       merchantFilter:
         enabled: false
       centralFilter:


### PR DESCRIPTION
# What
Allow for a edge case found with express-merchant-provisioning, this change allows filter rules that fall under the 'excludePaths' range to use a custom filter rule for each path instead of the default okta-central-filter and $app-okta-sso-filter.

test render with monochart-testing helm chart:
```
apiVersion: getambassador.io/v2
kind: FilterPolicy
metadata:
  annotations:
    meta.helm.sh/release-name: monochart-testing
    meta.helm.sh/release-namespace: monochart-testing
  creationTimestamp: "2025-03-14T17:27:57Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: monochart-testing
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: spoton-monochart
    helm.sh/chart: spoton-monochart-1.1.30
  name: monochart-testing-default
  namespace: ambassador
  resourceVersion: "243160340"
  uid: 7b37807d-f7fd-4fa7-82a4-d5d7d2a6b298
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--default
  rules:
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /sns/items*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /api/health-check*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /heartbeat*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /actuator/metrics*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /version*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      namespace: ambassador
      onAllow: continue
      onDeny: continue
    host: monochart-testing.monochart-testing.spoton.sh
    path: /actuator/info*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: '*'
```

compared to express-merchant-provisioning filter policy in staging-uw2-01
```
apiVersion: getambassador.io/v2
kind: FilterPolicy
metadata:
  annotations:
    meta.helm.sh/release-name: express-merchant-provisioning.staging-uw2-01
    meta.helm.sh/release-namespace: staging-uw2-01
  creationTimestamp: "2023-09-21T15:13:40Z"
  generation: 2
  labels:
    app.kubernetes.io/managed-by: Helm
  name: express-merchant-provisioning-staging-uw2-01-filter-policy
  namespace: staging-uw2-01
  resourceVersion: "125282124"
  uid: 1f7ff19d-9b77-4eb9-b7f4-d97fff3a7d87
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--ambassador-apigateway
  rules:
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      onDeny: continue
    host: express-merchant-provisioning.staging-uw2-01.express.spoton-dev.com
    path: /docs*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      onDeny: continue
    host: express-merchant-provisioning.staging-uw2-01.express.spoton-dev.com
    path: /heartbeat*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      onDeny: continue
    host: express-merchant-provisioning.staging-uw2-01.express.spoton-dev.com
    path: /metrics*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ""
      onDeny: continue
    host: express-merchant-provisioning.staging-uw2-01.express.spoton-dev.com
    path: /openapi.json*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: ambassador-apigateway-okta-central-filter
      namespace: ambassador-apigateway
    host: express-merchant-provisioning.staging-uw2-01.express.spoton-dev.com
    path: '*'
```

test with commented out customExcludePathFilters:

```
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--default
  rules:
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /sns/items*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /api/health-check*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /heartbeat*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /actuator/metrics*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /version*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
      onAllow: break
      onDeny: continue
    - ifRequestHeader:
        name: ""
        negate: false
      name: monochart-testing-okta-sso-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: /actuator/info*
  - filters:
    - ifRequestHeader:
        name: ""
        negate: false
      name: okta-central-filter
      namespace: ambassador
    host: monochart-testing.monochart-testing.spoton.sh
    path: '*'
```