### PR TITLE
Regex fix

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.33
+version: 1.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/_helpers.tpl
+++ b/monochart/templates/_helpers.tpl
@@ -125,7 +125,7 @@ VolumeMounts template block for deployable resources
 If the mount path ends with one of extensions specified below - we assume it's a regular file so
 we will mount it as a regular file (not a directory).
   */}}
-{{- if regexMatch ".*.(json|yaml|yml|txt|sh|js|ts|py)$" $config.mountPath }}
+{{- if regexMatch ".*\\.(json|yaml|yml|txt|sh|js|ts|py)$" $config.mountPath }}
   subPath: {{ regexFind "[a-zA-Z0-9_.-]*.(json|yaml|yml|txt|sh|js|ts|py)$" $config.mountPath }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What
Escape the "." character when parsing configmap volume mount names.

## Why
The spoton monochart has a regex which looks at configmap mountPath value and automatically tries to mount as files those with some specific extensions into the container.  It was supposed to look for patterns like "*.EXT".  The regex had a bug though, it was not escaping the "." character, so it was matching ANY character instead of just the ".".

A recent addition of the pattern "*.ts" resulted in it matching the mount path `/ephemeral-scripts` in restaurant-pos ephemerals, causing it to fail because it was mounting the files in `/ephemeral-scripts/ephemeral-scripts/`.