### PR TITLE
Adding Legacy Express Ambassador Support

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.34
+version: 1.1.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ambassador-mapping.yaml
+++ b/monochart/templates/ambassador-mapping.yaml
@@ -24,6 +24,14 @@ spec:
   {{- if $mapping.rewrite }}
   rewrite: {{ $mapping.rewrite }}
   {{- end }}
+  {{- if $mapping.ambassador_id }}
+  # This ambassador_id is only used for legacy Express deployments.  Do not use in the new cell
+  # based Kubernetes clusters.
+  ambassador_id: {{ $mapping.ambassador_id }}
+  {{- end }}
+  {{- if $mapping.redirect }}
+  path_redirect: {{ $mapping.redirect }}
+  {{- end }}
   service: {{ include "common.fullname" $root }}.{{ $root.Release.Namespace }}.svc.cluster.local
   timeout_ms: {{ $mapping.timeout_ms | default 60000 }}
 {{- end -}}


### PR DESCRIPTION
Adding support for legacy Express Ambassador deployments by adding

- `ambassador_id`
- `path_redirect`