### PR TITLE
Enhancement/ambassador-mappings-grpc-routing

### DIFF
--- a/monochart/templates/ambassador-mapping.yaml
+++ b/monochart/templates/ambassador-mapping.yaml
@@ -32,7 +32,7 @@ spec:
   {{- if $mapping.redirect }}
   path_redirect: {{ $mapping.redirect }}
   {{- end }}
-  service: {{ include "common.fullname" $root }}.{{ $root.Release.Namespace }}.svc.cluster.local{{ with $mapping.dest_port }}:{{ . }}{{ end }}
+  service: {{ include "common.fullname" $root }}.{{ $root.Release.Namespace }}.svc.cluster.local:{{- if $mapping.dest_port }}{{ $mapping.dest_port }}{{- else if $mapping.grpc }}8082{{- else }}80{{- end }}
   timeout_ms: {{ $mapping.timeout_ms | default 60000 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fix mappings to route traffic to the correct ports - grpc ports in express default to port 8082 like in express legacy clusters, port 80 for all other traffic, and use a custom dest_port if desired.