### PR TITLE
Fix(template): add persistent volume mount

### DIFF
--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -141,8 +141,10 @@ spec:
 {{- end }}
 
         volumeMounts:
+        {{- if .Values.persistence.enabled }}
         - mountPath: {{ $root.Values.persistence.mountPath | quote }}
-        name: storage
+          name: storage
+        {{- end }}
         {{- if .Values.FirstVolumeMounts }}
 {{ tpl .Values.FirstVolumeMounts . | indent 8 }}
         {{- if .Values.extraVolumeMounts }}

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -180,10 +180,10 @@ spec:
 {{ tpl .Values.VolumeMountsConfig . | indent 8 }}
         {{- end }}
       {{- if .Values.persistence.enabled }}
-      - name: storage
+        - name: storage
       {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $root := . -}}
+---
 {{- if .Values.deployment.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -139,6 +139,8 @@ spec:
 {{- end }}
 
         volumeMounts:
+        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
+        name: storage
         {{- if .Values.FirstVolumeMounts }}
 {{ tpl .Values.FirstVolumeMounts . | indent 8 }}
         {{- if .Values.extraVolumeMounts }}

--- a/monochart/templates/deployment.yaml
+++ b/monochart/templates/deployment.yaml
@@ -180,13 +180,13 @@ spec:
 {{ tpl .Values.VolumeMountsConfig . | indent 8 }}
         {{- end }}
       {{- if .Values.persistence.enabled }}
-        - name: storage
+      - name: storage
       {{- if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{- end }}
       {{- end }}
-      {{- include "monochart.files.volumes" . | nindent 8 }}
+      {{- include "monochart.files.volumes" . | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
- persistent volume (eg efs or ebs) has to be mounted in the pod to be usable
- indent fix to generate correct template when configmap and efs are attached to the same pod