### PR TITLE
fix: update cronjob jobTemplate labels

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.36
+version: 1.1.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -32,8 +32,7 @@ spec:
 {{ toYaml . | indent 12 }}
 {{- end }}
           labels:
-            app: {{ include "common.name" $root }}
-            release: {{ $root.Release.Name | quote }}
+{{ include "common.labels.standard" $root | indent 12 }}
 {{- with $cron.pod.labels }}
 {{ toYaml .| indent 12 }}
 {{- end }}


### PR DESCRIPTION
# What

Instead of some random labels, we should stick to out standard labels. This is a safe change, as `cronjobs`, `jobs` and `pods` spawned by them don't use any special selectors. This also doesn't break `services` as they use a special label `serve: true` added outside of the standard set of labels.
 
 # Why

@SpotOnInc/o11y relies on these labels to properly track workloads in Grafana