### PR TITLE
fix: revert commit 75892ee

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.37
+version: 1.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.36
+version: 1.1.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -32,7 +32,8 @@ spec:
 {{ toYaml . | indent 12 }}
 {{- end }}
           labels:
-{{ include "common.labels.standard" $root | indent 12 }}
+            app: {{ include "common.name" $root }}
+            release: {{ $root.Release.Name | quote }}
 {{- with $cron.pod.labels }}
 {{ toYaml .| indent 12 }}
 {{- end }}


### PR DESCRIPTION
# What

Reverting https://github.com/SpotOnInc/helmcharts/pull/134 while doing a roll forward to `1.1.38`.

# Why

https://spoton.slack.com/archives/CFBPX8NMQ/p1744206050170929?thread_ts=1744166403.574369&cid=CFBPX8NMQ

There seems to be an issue between cronjobs and network policies.