### PR TITLE
fix(jobs): fix cronjob and job labels; adjust network policies to actual app pods only

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.39
+version: 1.1.40
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -32,8 +32,7 @@ spec:
 {{ toYaml . | indent 12 }}
 {{- end }}
           labels:
-            app: {{ include "common.name" $root }}
-            release: {{ $root.Release.Name | quote }}
+{{ include "common.labels.standard" $root | indent 12 }}
 {{- with $cron.pod.labels }}
 {{ toYaml .| indent 12 }}
 {{- end }}

--- a/monochart/templates/job.yaml
+++ b/monochart/templates/job.yaml
@@ -27,8 +27,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       labels:
-        app: {{ include "common.name" $root }}
-        release: {{ $root.Release.Name | quote }}
+{{ include "common.labels.standard" $root | indent 12 }}
 {{- with $job.pod.labels }}
 {{ toYaml .| indent 8 }}
 {{- end }}

--- a/monochart/templates/networkpolicy.yaml
+++ b/monochart/templates/networkpolicy.yaml
@@ -40,6 +40,7 @@ spec:
   podSelector:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Egress
   egress:
@@ -67,6 +68,7 @@ spec:
   podSelector:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Egress
   egress:
@@ -92,6 +94,7 @@ spec:
   podSelector:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Egress
   egress:
@@ -124,6 +127,7 @@ spec:
   podSelector:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Ingress
   ingress:
@@ -181,6 +185,7 @@ spec:
   podSelector:
     matchLabels:
 {{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Egress
   egress:


### PR DESCRIPTION
# Why

[We made a decision](https://docs.corp.spoton.sh/operations/Architecture-Decision-Records/0018-kubernetes-label-updates/) to start using proper labels on our k8s resources, but back then we didn't fix jobs and cronjobs.  

[These labels became important to our Grafana efforts.](https://spoton.slack.com/archives/C071GCCALBT/p1743601633921649)

The network policies adjustments comes from the issue introduced by https://github.com/SpotOnInc/helmcharts/pull/134, [thread with details](https://spoton.slack.com/archives/CFBPX8NMQ/p1744166403574369). This special label `serve` is added to all of our standard application pods:
![image](https://github.com/user-attachments/assets/2095b287-77f2-4882-b1ab-486fd323da87)


