### PR TITLE
fix: use same set of labels for all policies

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.40
+version: 1.1.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/networkpolicy.yaml
+++ b/monochart/templates/networkpolicy.yaml
@@ -18,7 +18,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-{{ include "common.labels.short" $root | indent 6 }}
+{{ include "common.labels.standard" $root | indent 6 }}
+      serve: "true"
   policyTypes:
   - Ingress
   - Egress


### PR DESCRIPTION
# Why

For some reason the `deny-all` policy was catching a lot more then it should have.

