### PR TITLE
feat(jobs): add support for parallel jobs

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.41
+version: 1.1.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -30,6 +30,9 @@ spec:
 {{- if hasKey $cron "parallelism" }}
       parallelism: {{ $cron.parallelism }}
 {{- end }}
+{{- if hasKey $cron "completionMode" }}
+      completionMode: {{ $cron.completionMode }}
+{{- end }}
       template:
         metadata:
           name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/monochart/templates/cronjob.yaml
+++ b/monochart/templates/cronjob.yaml
@@ -24,6 +24,12 @@ spec:
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ default 300 $cron.activeDeadlineSeconds }}
+{{- if hasKey $cron "completions" }}
+      completions: {{ $cron.completions }}
+{{- end }}
+{{- if hasKey $cron "parallelism" }}
+      parallelism: {{ $cron.parallelism }}
+{{- end }}
       template:
         metadata:
           name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/monochart/templates/job.yaml
+++ b/monochart/templates/job.yaml
@@ -19,6 +19,12 @@ spec:
   activeDeadlineSeconds: {{ default 300 $job.activeDeadlineSeconds }}
   backoffLimit: {{ default 6 $job.backoffLimit }}
   ttlSecondsAfterFinished:  {{ default 600 $job.ttlSecondsAfterFinished }}
+{{- if hasKey $job "completions" }}
+  completions: {{ $job.completions }}
+{{- end }}
+{{- if hasKey $job "parallelism" }}
+  parallelism: {{ $job.parallelism }}
+{{- end }}
   template:
     metadata:
       name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/monochart/templates/job.yaml
+++ b/monochart/templates/job.yaml
@@ -25,6 +25,9 @@ spec:
 {{- if hasKey $job "parallelism" }}
   parallelism: {{ $job.parallelism }}
 {{- end }}
+{{- if hasKey $job "completionMode" }}
+  completionMode: {{ $job.completionMode }}
+{{- end }}
   template:
     metadata:
       name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -277,6 +277,9 @@ job:
     # annotations:
     #   name: value
     restartPolicy: Never
+    # https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs
+    # completions: 2  # Number of pod completions before the job is considered done
+    # parallelism: 5  # Number of pods that can run in parallel
     pod:
       # securityContext: {}
       # hostAliases:
@@ -306,6 +309,9 @@ cronjob:
     activeDeadlineSeconds: 300
     startingDeadlineSeconds: 180
     restartPolicy: Never
+    # https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs
+    # completions: 2  # Number of pod completions before the job is considered done
+    # parallelism: 5  # Number of pods that can run in parallel
     pod:
       # securityContext: {}
       # hostAliases:

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -280,6 +280,7 @@ job:
     # https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs
     # completions: 2  # Number of pod completions before the job is considered done
     # parallelism: 5  # Number of pods that can run in parallel
+    # completionMode: "Indexed"  # How Pod completions are tracked. Can be "NonIndexed" (default) or "Indexed"
     pod:
       # securityContext: {}
       # hostAliases:
@@ -312,6 +313,7 @@ cronjob:
     # https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs
     # completions: 2  # Number of pod completions before the job is considered done
     # parallelism: 5  # Number of pods that can run in parallel
+    # completionMode: "Indexed"  # How Pod completions are tracked. Can be "NonIndexed" (default) or "Indexed"
     pod:
       # securityContext: {}
       # hostAliases:


### PR DESCRIPTION
# What

Adding optional fields `completions`, `parallelism` and `completionMode` to job and cronjob templates. If fields are not set in the values, they shouldn't be set in the rendered manifests.

# Why

- [DEV-9326](https://spotonteam.atlassian.net/browse/DEV-9326)
- Payments domain has a use case for horizontally scaling their cronjobs

# References

[Parallel jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)

# Testing

Tested in `monochart-testing`:

```
For the job with parallelism (job-with-parallelism):
spec:
  activeDeadlineSeconds: 300
  backoffLimit: 6
  ttlSecondsAfterFinished:  600
  completions: 5
  parallelism: 2
The completions and parallelism fields are included in the manifest.

For the job without parallelism (job-without-parallelism):
spec:
  activeDeadlineSeconds: 300
  backoffLimit: 6
  ttlSecondsAfterFinished:  600
The completions and parallelism fields are not included in the manifest.

For the cronjob with parallelism (cronjob-with-parallelism):
  jobTemplate:
    spec:
      activeDeadlineSeconds: 300
      completions: 3
      parallelism: 2
The completions and parallelism fields are included in the manifest.

For the cronjob without parallelism (cronjob-without-parallelism):
  jobTemplate:
    spec:
      activeDeadlineSeconds: 300
The completions and parallelism fields are not included in the manifest.
```

[DEV-9326]: https://spotonteam.atlassian.net/browse/DEV-9326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ