### PR TITLE
Modify hpa template to support kOps apiVersion autoscaling/v1

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.42
+version: 1.1.43
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/README_HPA.md
+++ b/monochart/README_HPA.md
@@ -9,6 +9,8 @@ If the load decreases, and the number of Pods is above the configured minimum, t
 
 This document walks you through an example of enabling HorizontalPodAutoscaler to automatically manage scale for an example web app. This example workload is Apache httpd running some PHP code
 
+NOTE: on kOps clusters, only the CPU metric `targetCPUUtilizationPercentage` is supported.
+
 ## Default Values
 
 |Key|Value|

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- if .Values.hpa -}}
 {{- if .Values.hpa.enabled -}}
-{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v1
@@ -26,7 +26,7 @@ spec:
     name: {{ include "common.fullname" .  }}
   minReplicas: {{ .Values.hpa.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.hpa.autoscaling.maxReplicas }}
-  {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
+  {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
   metrics:
   {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -26,6 +26,7 @@ spec:
     name: {{ include "common.fullname" .  }}
   minReplicas: {{ .Values.hpa.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.hpa.autoscaling.maxReplicas }}
+  {{- if semverCompare ">=1.23" $root.Capabilities.KubeVersion.Version }}
   metrics:
   {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
@@ -43,5 +44,13 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
-{{- end }}
+  {{- else }}
+  {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
+  targetMemoryUtilizationPercentage: {{ .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,7 +1,11 @@
 {{- $root := . -}}
 {{- if .Values.hpa -}}
 {{- if .Values.hpa.enabled -}}
+{{- if semverCompare ">=1.23" $root.Capabilities.KubeVersion.Version }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- if .Values.hpa -}}
 {{- if .Values.hpa.enabled -}}
-{{- if semverCompare ">=1.23" $root.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v1
@@ -26,7 +26,7 @@ spec:
     name: {{ include "common.fullname" .  }}
   minReplicas: {{ .Values.hpa.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.hpa.autoscaling.maxReplicas }}
-  {{- if semverCompare ">=1.23" $root.Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
   metrics:
   {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource

--- a/monochart/templates/hpa.yaml
+++ b/monochart/templates/hpa.yaml
@@ -45,11 +45,9 @@ spec:
         averageUtilization: {{ .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
   {{- else }}
+  # Only the CPU metric is supported in autoscaling/v1
   {{- if .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
   targetCPUUtilizationPercentage: {{ .Values.hpa.autoscaling.targetCPUUtilizationPercentage }}
-  {{- end }}
-  {{- if .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
-  targetMemoryUtilizationPercentage: {{ .Values.hpa.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/monochart/values.yaml
+++ b/monochart/values.yaml
@@ -748,4 +748,5 @@ hpa:
     minReplicas: 3
     maxReplicas: 10
     targetCPUUtilizationPercentage: 70
+    # NOTE: the Memory metric is only supported on EKS clusters (kubernetes >= 1.23)
     targetMemoryUtilizationPercentage: 70


### PR DESCRIPTION
## What
- Modify hpa template to support kOps apiVersion `autoscaling/v1`.
- Only the CPU metric `targetCPUUtilizationPercentage` is supported in the older API version, so it is ignored when rendering the v1 template.

## Why
- kOps has `autoscaling/v1`, EKS has `autoscaling/v2`.

## Reference
- https://spoton.slack.com/archives/CFBPX8NMQ/p1746785096006959

## Testing

### kOps
https://github.com/SpotOnInc/monochart-testing/actions/runs/14933437477/job/41957040995

```shell
 ❯ kubectl get hpa monochart-testing -o yaml | yq .spec
maxReplicas: 3
minReplicas: 1
scaleTargetRef:
  apiVersion: apps/v1
  kind: Deployment
  name: monochart-testing
targetCPUUtilizationPercentage: 70
```

### EKS
https://github.com/SpotOnInc/monochart-testing/actions/runs/14933467531/job/41957049528

```shell
 ❯ kubectl get hpa monochart-testing -o yaml | yq .spec
maxReplicas: 3
metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 70
        type: Utilization
    type: Resource
  - resource:
      name: memory
      target:
        averageUtilization: 70
        type: Utilization
    type: Resource
minReplicas: 1
scaleTargetRef:
  apiVersion: apps/v1
  kind: Deployment
  name: monochart-testing```