### PR TITLE
DEV-9405: filterpolicy newline fix

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.44
+version: 1.1.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -61,5 +61,5 @@ spec:
           namespace: ambassador
     {{- end }}
 {{- end -}}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -5,7 +5,8 @@
 {{- $dnsName := include "common.fullname" $root -}}
 {{- if $filterPolicy.dnsNameOverride -}}
 {{-   $dnsName = $filterPolicy.dnsNameOverride -}}
-{{- end -}}
+{{- end }}
+
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: FilterPolicy

--- a/monochart/templates/ambassador-filter-policy.yaml
+++ b/monochart/templates/ambassador-filter-policy.yaml
@@ -60,5 +60,5 @@ spec:
           namespace: ambassador
     {{- end }}
 {{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
When there are multiple filterpolicies defined in a helm file, they are running together like this (end of one, beginning of another):

```yaml
    - host: subscription-service.express-nonprod-c1.express.spoton-dev.com
      path: "*"
      filters:
        - name: okta-central-filter
          namespace: ambassador---
apiVersion: getambassador.io/v3alpha1
kind: FilterPolicy
```
 
The `---` should not be at the end of the namespace line.