### PR TITLE
fix(ingress): properly handle public paths with the migration proxy enabled

### DIFF
--- a/monochart/Chart.yaml
+++ b/monochart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.47
+version: 1.1.48
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
-{{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
+{{- $serviceName := ternary (printf "cloud-migration-proxy-%s" (include "common.fullname" $root)) (include "common.fullname" $root) $ingress.useMigrationProxy -}}
 {{- if $ingress.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -90,7 +90,7 @@ spec:
             pathType: {{ if hasSuffix "*" . }} Prefix {{ else }} Exact {{ end }}
             backend:
               service:
-                name: {{ if $ingress.useMigrationProxy }} cloud-migration-proxy-{{ $serviceName }}-public {{ else }} {{ $serviceName }}-public {{ end }}
+                name: {{ $serviceName }}-public
                 port:
                   name: use-annotation
             {{- end }}
@@ -109,7 +109,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ if $ingress.useMigrationProxy }} cloud-migration-proxy-{{ $serviceName }} {{ else }} {{ $serviceName }} {{ end }}
+                name: {{ $serviceName }}
                 port:
                   {{- if default "<none>" $ingress.port | regexMatch "^[0-9]*$" }}
                   number: {{ $ingress.port }}

--- a/monochart/templates/ingress.yaml
+++ b/monochart/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- $root := . -}}
+{{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
-{{- $serviceName := ternary (printf "cloud-migration-proxy-%s" (include "common.fullname" $root)) (include "common.fullname" $root) $ingress.useMigrationProxy -}}
+{{- if $ingress.useMigrationProxy -}}
+{{- $serviceName = printf "cloud-migration-proxy-%s" (include "common.fullname" $root) -}}
+{{- end -}}
 {{- if $ingress.enabled }}
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Tested locally using these example values:

```
fullnameOverride: ingress-test
ingress:
  default:
    enabled: true
    annotations:
      alb.ingress.kubernetes.io/group.name: common
      alb.ingress.kubernetes.io/healthcheck-path: /livenessz
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
      alb.ingress.kubernetes.io/scheme: internet-facing
      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
      alb.ingress.kubernetes.io/target-type: ip
      external-dns.alpha.kubernetes.io/ttl: "60"
      kubernetes.io/ingress.class: alb
      kubernetes.io/tls-acme: "false"
    hosts:
      spoton.local: /*
    zscalerProxyIPs:
      - "34.238.231.165/32"
      - "34.202.59.188/32"
      - "34.197.162.237/32"
      
  default-with-proxy:
    enabled: true
    useMigrationProxy: true
    annotations:
      alb.ingress.kubernetes.io/group.name: common
      alb.ingress.kubernetes.io/healthcheck-path: /livenessz
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
      alb.ingress.kubernetes.io/scheme: internet-facing
      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
      alb.ingress.kubernetes.io/target-type: ip
      external-dns.alpha.kubernetes.io/ttl: "60"
      kubernetes.io/ingress.class: alb
      kubernetes.io/tls-acme: "false"
    hosts:
      spoton.local: /*  
    zscalerProxyIPs:
      - "34.238.231.165/32"
      - "34.202.59.188/32"
      - "34.197.162.237/32"
      
  public:
    enabled: true
    annotations:
      alb.ingress.kubernetes.io/group.name: common
      alb.ingress.kubernetes.io/healthcheck-path: /livenessz
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
      alb.ingress.kubernetes.io/scheme: internet-facing
      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
      alb.ingress.kubernetes.io/target-type: ip
      external-dns.alpha.kubernetes.io/ttl: "60"
      kubernetes.io/ingress.class: alb
      kubernetes.io/tls-acme: "false"
    hosts:
      spoton.local:
        - /*  
    zscalerProxyIPs:
      - "34.238.231.165/32"
      - "34.202.59.188/32"
      - "34.197.162.237/32"
      
  public-with-proxy:
    enabled: true
    useMigrationProxy: true
    annotations:
      alb.ingress.kubernetes.io/group.name: common
      alb.ingress.kubernetes.io/healthcheck-path: /livenessz
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
      alb.ingress.kubernetes.io/scheme: internet-facing
      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
      alb.ingress.kubernetes.io/target-type: ip
      external-dns.alpha.kubernetes.io/ttl: "60"
      kubernetes.io/ingress.class: alb
      kubernetes.io/tls-acme: "false"
    hosts:
      spoton.local:
        - /*  
    zscalerProxyIPs:
      - "34.238.231.165/32"
      - "34.202.59.188/32"
      - "34.197.162.237/32"
```

resulting in:
```
# Source: spoton-monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/group.name: common
    alb.ingress.kubernetes.io/healthcheck-path: /livenessz
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
    alb.ingress.kubernetes.io/target-type: ip
    external-dns.alpha.kubernetes.io/ttl: "60"
    kubernetes.io/ingress.class: alb
    kubernetes.io/tls-acme: "false"
  labels:
    app.kubernetes.io/name: ingress-test
    helm.sh/chart: spoton-monochart-1.1.48
    app.kubernetes.io/instance: ingress-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "latest"
    ingressName: default
  name: ingress-test-default
spec:
  rules:
    - host: "spoton.local"
      http:
        paths:
          - path: /*
            pathType: Prefix
            backend:
              service:
                name: ingress-test
                port:
                  name: default
---
# Source: spoton-monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/group.name: common
    alb.ingress.kubernetes.io/healthcheck-path: /livenessz
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
    alb.ingress.kubernetes.io/target-type: ip
    external-dns.alpha.kubernetes.io/ttl: "60"
    kubernetes.io/ingress.class: alb
    kubernetes.io/tls-acme: "false"
  labels:
    app.kubernetes.io/name: ingress-test
    helm.sh/chart: spoton-monochart-1.1.48
    app.kubernetes.io/instance: ingress-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "latest"
    ingressName: default-with-proxy
  name: ingress-test-default-with-proxy
spec:
  rules:
    - host: "spoton.local"
      http:
        paths:
          - path: /*
            pathType: Prefix
            backend:
              service:
                name: cloud-migration-proxy-ingress-test
                port:
                  name: default
---
# Source: spoton-monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/group.name: common
    alb.ingress.kubernetes.io/healthcheck-path: /livenessz
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
    alb.ingress.kubernetes.io/target-type: ip
    external-dns.alpha.kubernetes.io/ttl: "60"
    kubernetes.io/ingress.class: alb
    kubernetes.io/tls-acme: "false"
    # Expose paths to public access (without ZScaler)
    # Note the name (actions.<name>) can't be longer than 63 characters
    alb.ingress.kubernetes.io/actions.cloud-migration-proxy-ingress-test-public: '{
      "type":"forward",
      "forwardConfig":{
        "targetGroups":[{
          "serviceName":"cloud-migration-proxy-ingress-test",
          "servicePort": "default",
          "weight":100}
        ]}
    }'
    # Block entire traffic except ZScaler users
    alb.ingress.kubernetes.io/conditions.cloud-migration-proxy-ingress-test: '[{
      "field":"source-ip",
      "sourceIpConfig": {
        "values":["34.238.231.165/32","34.202.59.188/32","34.197.162.237/32"]
      }
    }]'
  labels:
    app.kubernetes.io/name: ingress-test
    helm.sh/chart: spoton-monochart-1.1.48
    app.kubernetes.io/instance: ingress-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "latest"
    ingressName: public
  name: ingress-test-public
spec:
  rules:
    - host: "spoton.local"
      http:
        paths:
          # ALB support (EKS)
          - path: /
            pathType:  Prefix 
            backend:
              service:
                name: cloud-migration-proxy-ingress-test-public
                port:
                  name: use-annotation
          - path: /
            pathType: Prefix
            backend:
              service:
                name: cloud-migration-proxy-ingress-test
                port:
                  name: default
---
# Source: spoton-monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/group.name: common
    alb.ingress.kubernetes.io/healthcheck-path: /livenessz
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
    alb.ingress.kubernetes.io/target-type: ip
    external-dns.alpha.kubernetes.io/ttl: "60"
    kubernetes.io/ingress.class: alb
    kubernetes.io/tls-acme: "false"
    # Expose paths to public access (without ZScaler)
    # Note the name (actions.<name>) can't be longer than 63 characters
    alb.ingress.kubernetes.io/actions.cloud-migration-proxy-ingress-test-public: '{
      "type":"forward",
      "forwardConfig":{
        "targetGroups":[{
          "serviceName":"cloud-migration-proxy-ingress-test",
          "servicePort": "default",
          "weight":100}
        ]}
    }'
    # Block entire traffic except ZScaler users
    alb.ingress.kubernetes.io/conditions.cloud-migration-proxy-ingress-test: '[{
      "field":"source-ip",
      "sourceIpConfig": {
        "values":["34.238.231.165/32","34.202.59.188/32","34.197.162.237/32"]
      }
    }]'
  labels:
    app.kubernetes.io/name: ingress-test
    helm.sh/chart: spoton-monochart-1.1.48
    app.kubernetes.io/instance: ingress-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "latest"
    ingressName: public-with-proxy
  name: ingress-test-public-with-proxy
spec:
  rules:
    - host: "spoton.local"
      http:
        paths:
          # ALB support (EKS)
          - path: /
            pathType:  Prefix 
            backend:
              service:
                name: cloud-migration-proxy-ingress-test-public
                port:
                  name: use-annotation
          - path: /
            pathType: Prefix
            backend:
              service:
                name: cloud-migration-proxy-ingress-test
                port:
                  name: default
```